### PR TITLE
Fixed line # box unchecking if line # is 0

### DIFF
--- a/Emrald_Site/EditForms/VariableEditor.html
+++ b/Emrald_Site/EditForms/VariableEditor.html
@@ -89,11 +89,11 @@
                     <div ng-if="data.docType.value == 'dtTextRegEx'" style="display: contents;">
                         <div id="RegExLinePanel" style="display: table-row;">
                             <div style="display: table-cell; white-space: nowrap;">
-                                <input type="checkbox" id="RegExLineChk" name="RegExLineChk" ng-model="data.useRegExLine">
+                                <input type="checkbox" id="RegExLineChk" name="RegExLineChk" ng-model="data.useRegExLine" ng-change="initializeRegExLine()">
                                 <label for="RegExLineChk">Line #:</label>
                             </div>
                             <div style="display: table-cell; white-space: nowrap;">
-                                <input id="RegExLineInp" name="regExLine" size="4" ng-model="data.regExLine" ng-if="data.useRegExLine">
+                                <input id="RegExLineInp" name="regExLine" size="4" ng-model="data.regExLine" ng-if="data.useRegExLine" type="number" min="0">
                                 <small> <i>(Use if a line after the RegExp match is desired.)</i></small>
                             </div>
                         </div>
@@ -102,17 +102,17 @@
                                 <label for="RegExLineChk">Beg Pos:</label>
                             </div>
                             <div style="display: table-cell; white-space: nowrap;">
-                                <input size="4" ng-model="data.regExBegPos">
+                                <input size="4" ng-model="data.regExBegPos" type="number" min="0">
                                 <small> <i>(Line start position, use 0 is the first character.)</i></small>
                             </div>
                         </div>
                         <div id="RegExNumCharsPanel" style="display: table-row;" ng-if="data.useRegExLine">
                             <div style="display: table-cell; white-space: nowrap;">
-                                <input type="checkbox" id="RegExNumCharsChk" name="RegExNumCharsChk" ng-model="data.useRegExNumChars">
+                                <input type="checkbox" id="RegExNumCharsChk" name="RegExNumCharsChk" ng-model="data.useRegExNumChars" ng-change="initializeRegExNumChars()">
                                 <label for="RegExNumCharsChk">Num Chars:</label>
                             </div>
                             <div style="display: table-cell; white-space: nowrap;">
-                                <input id="RegExNumCharsInp" size="4" ng-model="data.regExNumChars" ng-if="data.useRegExNumChars">
+                                <input id="RegExNumCharsInp" size="4" ng-model="data.regExNumChars" ng-if="data.useRegExNumChars" type="number" min="0">
                                 <small> <i>(Use for a specific # of characters, set to 0 for until next space, uncheck for end of line.)</i></small>
                             </div>
                         </div>

--- a/Emrald_Site/EditForms/VariableEditor.html
+++ b/Emrald_Site/EditForms/VariableEditor.html
@@ -94,7 +94,7 @@
                             </div>
                             <div style="display: table-cell; white-space: nowrap;">
                                 <input id="RegExLineInp" name="regExLine" size="4" ng-model="data.regExLine" ng-if="data.useRegExLine" type="number" min="0">
-                                <small> <i>(Use if a line after the RegExp match is desired.)</i></small>
+                                <small> <i>(Use if exact Regular Expression match is not desired.)</i></small>
                             </div>
                         </div>
                         <div id="RegExBegPosPanel" style="display: table-row;" ng-if="data.useRegExLine">

--- a/Emrald_Site/EditForms/VariableEditor.js
+++ b/Emrald_Site/EditForms/VariableEditor.js
@@ -222,8 +222,8 @@ function OnLoad(dataObj) {
 
           //for regular expression items
           if (scope.data.docType.value == "dtTextRegEx") {
-            scope.data.useRegExLine = (variableData.regExpLine !== null); // checked if a line is specified
-            scope.data.useRegExNumChars = (variableData.numChars !== null); //checked if not null
+            scope.data.useRegExLine = (variableData.regExpLine >= 0); // checked if a line is specified
+            scope.data.useRegExNumChars = (variableData.numChars >= 0); //checked if not null
             scope.data.regExLine = variableData.regExpLine;
             scope.data.regExBegPos = variableData.begPosition;
             scope.data.regExNumChars = variableData.numChars;
@@ -309,16 +309,16 @@ function GetDataObject() {
     dataObj.pathMustExist = scope.data.resetOnRuns;
     if (scope.data.docType.value == "dtTextRegEx") {
       //set the extra regExp options to not used unless checked
-      dataObj.regExpLine = null;
-      dataObj.begPosition = null;
-      dataObj.numChars = null;
+      dataObj.regExpLine = -1;
+      dataObj.begPosition = 0;
+      dataObj.numChars = -1;
 
       //Assign if checked 
       if (scope.data.useRegExLine) {
         dataObj.regExpLine = scope.data.regExLine;
         dataObj.begPosition = scope.data.regExBegPos;
       }
-      if (scope.data.useRegExNumChars) {
+      if (scope.data.useRegExLine && scope.data.useRegExNumChars) {
         dataObj.numChars = scope.data.regExNumChars;
       }
     }
@@ -461,10 +461,10 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
     varLink: "",
     
     useRegExLine: false,
-    regExLine: null,
-    regExBegPos: null,
+    regExLine: -1,
+    regExBegPos: 0,
     useRegExNumChars: false,
-    regExNumChars: null,
+    regExNumChars: -1,
 
     sim3DId: "",
 
@@ -523,7 +523,7 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
    * When the line # checkbox is clicked, this will initialize the value to 0 if it's not already set.
    */
   $scope.initializeRegExLine = function () {
-    if ($scope.data.regExLine === null) {
+    if ($scope.data.regExLine === -1) {
       $scope.data.regExLine = 0;
       $scope.data.regExBegPos = 0;
     }
@@ -534,7 +534,7 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
    * When the num chars checkbox is clicked, this will initialize the value to 0 if it's not already set.
    */
   $scope.initializeRegExNumChars = function () {
-    if ($scope.data.regExNumChars === null) {
+    if ($scope.data.regExNumChars === -1) {
       $scope.data.regExNumChars = 0;
     }
   }

--- a/Emrald_Site/EditForms/VariableEditor.js
+++ b/Emrald_Site/EditForms/VariableEditor.js
@@ -527,7 +527,6 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
       $scope.data.regExLine = 0;
       $scope.data.regExBegPos = 0;
     }
-    $scope.data.useRegExNumChars = $scope.data.useRegExLine && ($scope.data.regExNumChars !== null);
   }
 
   /**

--- a/Emrald_Site/EditForms/VariableEditor.js
+++ b/Emrald_Site/EditForms/VariableEditor.js
@@ -310,7 +310,7 @@ function GetDataObject() {
     if (scope.data.docType.value == "dtTextRegEx") {
       //set the extra regExp options to not used unless checked
       dataObj.regExpLine = null;
-      dataObj.begPosition = 0;
+      dataObj.begPosition = null;
       dataObj.numChars = null;
 
       //Assign if checked 
@@ -462,7 +462,7 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
     
     useRegExLine: false,
     regExLine: null,
-    regExBegPos: 0,
+    regExBegPos: null,
     useRegExNumChars: false,
     regExNumChars: null,
 
@@ -525,7 +525,9 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
   $scope.initializeRegExLine = function () {
     if ($scope.data.regExLine === null) {
       $scope.data.regExLine = 0;
+      $scope.data.regExBegPos = 0;
     }
+    $scope.data.useRegExNumChars = $scope.data.useRegExLine && ($scope.data.regExNumChars !== null);
   }
 
   /**

--- a/Emrald_Site/EditForms/VariableEditor.js
+++ b/Emrald_Site/EditForms/VariableEditor.js
@@ -48,7 +48,7 @@ function nameIsDefaultValue() {
     if (scope.name === '') {
         return true;
     }
-    result = false;
+    var result = false;
     scope.namingPatterns.forEach(defaultName => {
         if (scope.name === defaultName.NamePattern) {
             result = true;
@@ -222,8 +222,8 @@ function OnLoad(dataObj) {
 
           //for regular expression items
           if (scope.data.docType.value == "dtTextRegEx") {
-            scope.data.useRegExLine = (variableData.regExpLine > 0); // checked if a line is specified
-            scope.data.useRegExNumChars = (variableData.numChars >= 0); //checked if not -1
+            scope.data.useRegExLine = (variableData.regExpLine !== null); // checked if a line is specified
+            scope.data.useRegExNumChars = (variableData.numChars !== null); //checked if not null
             scope.data.regExLine = variableData.regExpLine;
             scope.data.regExBegPos = variableData.begPosition;
             scope.data.regExNumChars = variableData.numChars;
@@ -309,9 +309,9 @@ function GetDataObject() {
     dataObj.pathMustExist = scope.data.resetOnRuns;
     if (scope.data.docType.value == "dtTextRegEx") {
       //set the extra regExp options to not used unless checked
-      dataObj.regExpLine = 0;
+      dataObj.regExpLine = null;
       dataObj.begPosition = 0;
-      dataObj.numChars = -1;
+      dataObj.numChars = null;
 
       //Assign if checked 
       if (scope.data.useRegExLine) {
@@ -461,10 +461,10 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
     varLink: "",
     
     useRegExLine: false,
-    regExLine: 0,
+    regExLine: null,
     regExBegPos: 0,
-    useRegExNumChars: true,
-    regExNumChars: -1,
+    useRegExNumChars: false,
+    regExNumChars: null,
 
     sim3DId: "",
 
@@ -518,6 +518,24 @@ variableModule.controller("variableController", ["$scope", function ($scope) {
     { name: "Second", value: "trSeconds", abbr: "Sec" }
   ];
   $scope.accrualUnit = $scope.accrualUnits[1]; // Default to Hours
+
+  /**
+   * When the line # checkbox is clicked, this will initialize the value to 0 if it's not already set.
+   */
+  $scope.initializeRegExLine = function () {
+    if ($scope.data.regExLine === null) {
+      $scope.data.regExLine = 0;
+    }
+  }
+
+  /**
+   * When the num chars checkbox is clicked, this will initialize the value to 0 if it's not already set.
+   */
+  $scope.initializeRegExNumChars = function () {
+    if ($scope.data.regExNumChars === null) {
+      $scope.data.regExNumChars = 0;
+    }
+  }
 
 }]);
 


### PR DESCRIPTION
Closes #4 

Previously, when a variable's properties were opened, the VariableEditor would store a value of zero in regExpLine if the line # was not being used, which obviously caused a problem when the user deliberately wants to use the first line. I changed it to instead store regExpLine as null if the line # is not being used, making zero an acceptable value as intended.

Summary of changes:
- VariableEditor.html:
    - Line 92, 111: I added these functions that are called when the line # and num chars checkboxes are clicked to set the default value for their respective input boxes. Since regExpLine and regExpNumChars are both now being stored as null when unchecked, without these functions the input boxes would initially show up empty, so these functions maintain how the editor previously behaved by having the boxes always initially contain 0.
    - Line 96, 105, 115: I set the input type to number and min to 0 to enable the browser's number buttons for input boxes.
- VariableEditor.js:
    - Line 225, 226: Updated the checking conditions to check if the value is null
    - Line 312, 314, 464, 467: Updated the initial values to null
    - Line 466: Previously, the num chars box would start out checked, but with a value of -1 which means that it would become unchecked when saved. I think the better behavior is to just have the box initially unchecked.
    - Line 522-539: The new initializer functions.