### PR TITLE
Fixed all diagram windows names changing

### DIFF
--- a/Emrald_Site/scripts/UI/State.js
+++ b/Emrald_Site/scripts/UI/State.js
@@ -131,7 +131,7 @@ function DataChanged(dataObj) {
 				mainApp.createTreeStructure(stateData);
 				mainApp.LoadData(graph, parent, stateData.StateList);
 				graph.updateOwnership();
-				if (typeof UpdateFrameTitle == "function") {
+				if (typeof UpdateFrameTitle == "function" && dataObj.id === stateData.id) {
 						UpdateFrameTitle("Diagram: " + dataObj.name);
 				}
 			


### PR DESCRIPTION
Closes #34.

All windows receive a diagram object whenever any diagram's properties are edited. This resulted in the bug in #34, and in addition to that, whenever a diagram properties window was updated the same problem would occur.
So, in State.js, I added a check so that the window title is only updated if the diagram being updated is the same diagram displayed in the window. This allows each window to still receive all updates as usual, but fixes the UI bug.