### PR TITLE
Window dragging & resizing improvements

### DIFF
--- a/Emrald_Site/index.cshtml
+++ b/Emrald_Site/index.cshtml
@@ -113,7 +113,7 @@
       <div id="SidePanel"
         style="position: absolute; top: 76px; bottom: 2px; background-color: teal; margin: 2px; float: left;">
       </div>
-      <div id="ContentPanel" style="position: absolute; left: 165px; top: 76px; bottom: 0px; right: 0px; margin: 2px;
+      <div id="ContentPanel" style="position: absolute; left: 212px; top: 76px; bottom: 0px; right: 0px; margin: 2px;
            clip: rect(auto, auto, auto, auto);">
       </div>
     </div>

--- a/Emrald_Site/scripts/UI/WindowFrame.js
+++ b/Emrald_Site/scripts/UI/WindowFrame.js
@@ -415,7 +415,7 @@ mxWindow.createFrame = function (bottomButtons, headButtons, dataObj, isModal, x
   wf.setResizable(true);
 
   $(wf.div).draggable({
-
+    containment: "#ContentPanel",
     handle: wf.title,
 
     start: function () {
@@ -621,6 +621,27 @@ mxWindow.prototype.installCloseHandler = function () {
   //With 'click' it works for all IE, Chrome and SF.
   this.closeImg.addEventListener('click', mxUtils.bind(this, onCloseForm), true);
 };
+
+/**
+ * Overrides mxWindow's resize function to rely use jQuery UI
+ * 
+ * @param {boolean} resizable The resizeable state.
+ */
+mxWindow.prototype.setResizable = function(resizable = false) {
+  const w = this;
+  $(this.div)
+    .resizable()
+    .on('resizestart', (evt) => {
+      w.fireEvent(new mxEventObject(mxEvent.RESIZE_START, 'event', evt));
+    })
+    .on('resize', (evt, ui) => {
+      w.setSize(ui.size.width, ui.size.height);
+      w.fireEvent(new mxEventObject(mxEvent.RESIZE, 'event', evt));
+    })
+    .on('resizestop', (evt) => {
+      w.fireEvent(new mxEventObject(mxEvent.RESIZE_END, 'event', evt));
+    });
+}
 
 // --- these code is for future use: for adding menu.
 //function getServerFile(url, callbackFn) {


### PR DESCRIPTION
Closes #41, closes #14.

To fix #14 and the first two points in #41, I simply specified a containment element for the jQuery UI draggable directive. Now, windows can't be dragged over the sidebar, behind the menu, or off to infinity beyond the screen.
To fix the third point in #41, I overrode mxGraph's resizing function to use jQuery UI's resizable directive instead, which is better anyway as it allows dragging by clicking anywhere on the window edge.