### PR TITLE
Fixed state renaming error

### DIFF
--- a/Emrald_Site/EditForms/StateEditor.js
+++ b/Emrald_Site/EditForms/StateEditor.js
@@ -91,14 +91,14 @@ function OnLoad(dataObj) {
 function GetDataObject() {
   stateData = stateData || {};
   var scope = angular.element(document.querySelector('#stateControllerPanel')).scope();
+  var oldName = stateData.name;
   scope.$apply(function () {
     stateData.name = scope.name;
     stateData.desc = scope.desc;
 
     //----------------NEW CODE ---------------------
     //This update is to the diagram's singleState that this State belongs to.
-
-    var diagram = stateData.sidebar.getDiagramByStateName(stateData.name).Diagram;
+    var diagram = stateData.sidebar.getDiagramByStateName(oldName).Diagram;
     //if (!diagram) return stateData;
     if (diagram.diagramType != "dtPlant") {
       if (scope.StatusValue == "Unknown") {


### PR DESCRIPTION
I was not able to exactly reproduce #18, so I can't say for sure that this closes that issue. However, in attempting to reproduce the issue, I noticed an error occurring where the form was trying to use the new state name to find the state object to update, and of course was not finding the object because the it still had the old name.

@otancm, could you check if this fixes the bug in #18 ?