### PR TITLE
Fixed gap left by my previous sidebar improvements

### DIFF
--- a/Emrald_Site/index.cshtml
+++ b/Emrald_Site/index.cshtml
@@ -113,7 +113,7 @@
       <div id="SidePanelContainer" style="position: absolute; top: 76px; bottom: 2px; background-color: teal; margin: 2px; float: left;">
         <div id="SidePanel"></div>
       </div>
-      <div id="ContentPanel" style="position: absolute; left: 212px; top: 76px; bottom: 0px; right: 0px; margin: 2px;
+      <div id="ContentPanel" style="position: absolute; left: 180px; top: 76px; bottom: 0px; right: 0px; margin: 2px;
            clip: rect(auto, auto, auto, auto);">
       </div>
     </div>

--- a/Emrald_Site/scripts/UI/simApp.js
+++ b/Emrald_Site/scripts/UI/simApp.js
@@ -464,7 +464,7 @@ var simApp;
         resize: function (evt, ui) {
           $('#ContentPanel').css({
             left: sideBar.clientWidth +
-              $('.ui-resizable-handle.ui-resizable-e').width() + parseInt(sideBarContainer.style.marginLeft) + parseInt(sideBarContainer.style.marginRight)
+              $('.ui-resizable-handle.ui-resizable-e').width() + parseInt(sideBarContainer.style.marginLeft) + parseInt(sideBarContainer.style.marginRight) + 24
             //,"border-style": "solid", "border-color": "red", "border-width": "1px"
           });
         }


### PR DESCRIPTION
In my commit with sidebar improvements, I forgot to adjust the position of the content window to account for the new layout of the sidebar, so this commit just moves the content panel to the left to get rid of the awkward gap.