### PR TITLE
Improved validation behavior

### DIFF
--- a/Emrald_Site/EditForms/EventEditor.js
+++ b/Emrald_Site/EditForms/EventEditor.js
@@ -108,6 +108,10 @@ function isModified() {
 }
 
 function ValidateData() {
+    var scope = angular.element(document.querySelector('#EEControllerPanel')).scope();
+    if (!scope.variable) {
+        return "Please specify an External Sim Variable before saving the event.";
+    }
     return "";
 }
 

--- a/Emrald_Site/scripts/UI/WindowFrame.js
+++ b/Emrald_Site/scripts/UI/WindowFrame.js
@@ -475,7 +475,7 @@ function windowClosing(btnStatus, callHomeFn, evt) {
   if (btnStatus in SetOf(['Save', 'OK', 'Ok', 'Save As New'])) {
     if (evt.frame.contentWindow.ValidateData) {
       var msg = evt.frame.contentWindow.ValidateData();
-      if (typeof msg === 'string' && msg) {
+      if (typeof msg === 'string' && msg.length > 0) {
         alert('Validation failed, cause: ' + msg);
         return false;
       }
@@ -502,7 +502,12 @@ function windowClosing(btnStatus, callHomeFn, evt) {
       }
     }
     if (status) {
-      if (evt.frame.contentWindow.GetDataObject && btnStatus == "Close")
+      var useDataObj = true;
+      if (evt.frame.contentWindow.ValidateData) {
+        var msg = evt.frame.contentWindow.ValidateData();
+        useDataObj = !(typeof msg === 'string' && msg.length > 0);
+      }
+      if (evt.frame.contentWindow.GetDataObject && btnStatus == "Close" && useDataObj)
         dataObj = evt.frame.contentWindow.GetDataObject();
       if (callHomeFn) status = callHomeFn(btnStatus, dataObj);
     }


### PR DESCRIPTION
Closes #64 

Clicking the "X" button on windows requires constructing the data object, but didn't check if the object could be constructed, leading to reading properties of null objects and errors breaking window behavior. I added a condition to first call the editor's ValidateData function to determine if the object is able to be constructed. I also filled out the event editor's validation function to address #64 .