### PR TITLE
Path results update

### DIFF
--- a/SimulationEngine/ProcessSimBatch.cs
+++ b/SimulationEngine/ProcessSimBatch.cs
@@ -90,7 +90,8 @@ namespace SimulationEngine
 
     //public Dictionary<string, double> variableVals { get { return _variableVals; } }
     public Dictionary<string, FailedItems> keyFailedItems = new Dictionary<string, FailedItems>(); //key = StateName, value = cut sets
-    public Dictionary<string, ResultState> keyPaths = new Dictionary<string, ResultState>();
+    public Dictionary<string, KeyStateResult> keyPaths = new Dictionary<string, KeyStateResult>();
+    public Dictionary<string, ResultState> otherPaths = new Dictionary<string, ResultState>();
     private Dictionary<string, Dictionary<string, List<string>>> _variableVals = new Dictionary<string, Dictionary<string, List<string>>>();
     public TProgressCallBack progressCallback;
     public List<string> logVarVals = new List<string>();
@@ -272,7 +273,7 @@ namespace SimulationEngine
               pathOutputFile.WriteLine("Run - " + i.ToString());
             }
 
-            trackSim.GetKeyPaths(keyPaths);
+            trackSim.GetKeyPaths(keyPaths, otherPaths);
             
             foreach (SimulationEngine.ResultState path in keyPaths.Values)
             {
@@ -369,7 +370,7 @@ namespace SimulationEngine
         foreach (var keyS in resultObj.keyStates)
         {
           // Dictionary<string, int> depth = new Dictionary<string, int>();
-          SetResultStatsRec(keyS, inStateCnts, curI);//, depth);
+          //SetResultStatsRec(keyS, inStateCnts, curI);//, depth);
 
           if(_variableVals.Count > 0) //if there are any being tracked, they should have a value for each key state.
             keyS.watchVariables = _variableVals[keyS.name];
@@ -425,17 +426,17 @@ namespace SimulationEngine
     /// <param name="curRes"></param>
     /// <param name="inStateCnts"></param>
     /// <param name="totCnt"></param>
-    private void SetResultStatsRec(ResultState curRes, Dictionary<string, int> inStateCnts, int totCnt)//, Dictionary<string, int> depths)
-    { 
-      foreach (var i in curRes.causeDict.Values)
-      {
-        if (i.fromState != null)
-          SetResultStatsRec(i.fromState, inStateCnts, curRes.count);//, depths); //key states use total runs for count, other states use total times in the state.
-      }
+    //private void SetResultStatsRec(ResultState curRes, Dictionary<string, int> inStateCnts, int totCnt)//, Dictionary<string, int> depths)
+    //{ 
+    //  foreach (var i in curRes.enterDict.Values)
+    //  {
+    //    if (i.otherState != null)
+    //      SetResultStatsRec(i.otherState, inStateCnts, curRes.count);//, depths); //key states use total runs for count, other states use total times in the state.
+    //  }
 
-      //decrement depth for recursive call
-      //depths[curRes.name] -= 1;
-    }
+    //  //decrement depth for recursive call
+    //  //depths[curRes.name] -= 1;
+    //}
 
     public void LogResults(TimeSpan runTime, int runCnt, bool finalValOnly)
     {

--- a/SimulationEngine/ProcessSimBatch.cs
+++ b/SimulationEngine/ProcessSimBatch.cs
@@ -275,7 +275,7 @@ namespace SimulationEngine
 
             trackSim.GetKeyPaths(keyPaths, otherPaths);
             
-            foreach (SimulationEngine.ResultState path in keyPaths.Values)
+            foreach (SimulationEngine.ResultStateBase path in keyPaths.Values)
             {
               string keyStateName = path.name;
 
@@ -360,7 +360,9 @@ namespace SimulationEngine
         OverallResults resultObj = new OverallResults();
         resultObj.name = this._lists.name;
         resultObj.keyStates = keyPaths.Values.ToList();
+        resultObj.otherStatePaths = otherPaths.Values.ToList();
         resultObj.numRuns = curI;
+        resultObj.CalcStats();
         Dictionary<string, int> inStateCnts = new Dictionary<string, int>();
         //foreach (var keyS in resultObj.keyStates)
         //{

--- a/SimulationEngine/ResultObject.cs
+++ b/SimulationEngine/ResultObject.cs
@@ -208,6 +208,7 @@ namespace SimulationEngine
 
   public class EnterExitCause
   {
+    [JsonIgnore]
     public string desc = ""; //Enter key of -  prevState.name + ", " + eventName + ", " + actionName;
                              //Enter key of -  eventName + ", " + actionName + ", " + nextState.name;
     public string name = ""; //eventName + " -> " + actionName

--- a/SimulationEngine/ResultObject.cs
+++ b/SimulationEngine/ResultObject.cs
@@ -15,7 +15,19 @@ namespace SimulationEngine
   {
     public string name;
     public int numRuns = 0;
-    public List<ResultState> keyStates = null;
+    public List<KeyStateResult> keyStates = null;
+    public List<ResultState> otherStatePaths = null;
+  }
+
+  public class KeyStateResult : ResultState
+  {
+    [JsonIgnore]
+    public Dictionary<string, ResultState> pathsLookup = new Dictionary<string, ResultState>();
+    
+    public List<ResultState> paths { get { return pathsLookup.Values.ToList(); } }
+
+    public KeyStateResult(string name) : base(name) { }
+
   }
 
   public class ResultState
@@ -25,20 +37,29 @@ namespace SimulationEngine
     public double rate5th { get { return _rate5th; } }
     public double rate95th { get { return _rate95th; } }
     public int count { get { return _count; } }
-    
+
+    [JsonIgnore]
     public List<TimeSpan> times { get { return _times; } }
     public TimeSpan timeMean { get { return _totalTime / count; } }
-    public TimeSpan timeStdDeviation { get {return GetTimeStdDev(); } } 
+    public TimeSpan timeStdDeviation { get {return GetTimeStdDev(); } }
+    public TimeSpan timeMin { get {return _timeMin; } }
+    public TimeSpan timeMax { get {return _timeMax; } }
+
     public Dictionary<string, List<string>> watchVariables = new Dictionary<string, List<string>>();
     [JsonIgnore]
-    public Dictionary<string, Cause> causeDict { get; set; } = new Dictionary<string, Cause>(); //key will be from state, event, and action 
-    public Cause[] causes { get { return causeDict.Values.ToArray(); } }
+    public Dictionary<string, EnterExitCause> enterDict { get; set; } = new Dictionary<string, EnterExitCause>(); //key will be from state, event, and action 
+    [JsonIgnore]
+    public Dictionary<string, EnterExitCause> exitDict { get; set; } = new Dictionary<string, EnterExitCause>(); //key will be from state, event, and action
+    public EnterExitCause[] entries { get { return enterDict.Values.ToArray(); } }
+    public EnterExitCause[] exits { get { return exitDict.Values.ToArray(); } }
     private TimeSpan _totalTime = TimeSpan.Zero;
     private List<TimeSpan> _times = new List<TimeSpan>();
     private int _count = 0;
     private double _rate = 0;
     private double _rate5th = 0;
     private double _rate95th = 0;
+    private TimeSpan _timeMin = TimeSpan.FromSeconds(0);
+    private TimeSpan _timeMax = TimeSpan.FromSeconds(0);
 
     public ResultState(string name)
     {
@@ -67,8 +88,13 @@ namespace SimulationEngine
 
     public void AddTime(TimeSpan newTime)
     {
+      if ((_count == 0) || (newTime < _timeMin))
+        _timeMin = newTime;
+      if (newTime > _timeMax)
+        _timeMax = newTime;
+
       this._times.Add(newTime);
-      this._totalTime += newTime;
+      this._totalTime += newTime;      
       ++_count;
     }  
 
@@ -79,21 +105,66 @@ namespace SimulationEngine
       _rate5th = Math.Round(_rate - range, 8);
       _rate95th = Math.Round(_rate + range, 8);
     }
-    
 
+    /// <summary>
+    /// This is used to collapse in an item times to just one, using the mean. 
+    /// </summary>
+    public void Collapse()
+    {
+      TimeSpan newTime = this.timeMean;
+      this._times.Clear();
+      this._count = 0;
+      this._rate = 0;
+      this._rate5th = 0;
+      this._rate95th = 0;
+      this._totalTime = TimeSpan.FromSeconds(0);
+      this._timeMin = TimeSpan.FromSeconds(0);
+      this._timeMax = TimeSpan.FromSeconds(0);
+
+      this.AddTime(newTime);
+    }
+
+    /// <summary>
+    /// This pulls in the data from another ResultState, adding the mean time as a time and combining all the causes
+    /// </summary>
+    /// <param name="include"></param>
+    public void Combine(ResultState include)
+    {
+      this.AddTime(include.timeMean);
+      EnterExitCause curCause = null;
+           
+      foreach (var item in include.enterDict.Values)
+      {
+        if (!this.enterDict.TryGetValue(item.desc, out curCause))
+          this.enterDict.Add(item.desc, item);
+        else 
+          curCause.cnt += item.cnt;
+      }
+
+      foreach (var item in include.exitDict.Values)
+      {
+        if (!this.exitDict.TryGetValue(item.desc, out curCause))
+          this.exitDict.Add(item.desc, item);
+        else
+          curCause.cnt += item.cnt;
+      }
+    }
   }
 
-  public class Cause
+  public class EnterExitCause
   {
-    public string desc = "";
-    public string name = "";
-    public ResultState fromState = null;
+    public string desc = ""; //Enter key of -  prevState.name + ", " + eventName + ", " + actionName;
+                             //Enter key of -  eventName + ", " + actionName + ", " + nextState.name;
+    public string name = ""; //eventName + " -> " + actionName
+    public string otherState = ""; //too or from state 
+    public int cnt = 0; //number of times this cause leads to parent state.
 
-    public Cause(string name, string desc = "", ResultState from = null)
+    public EnterExitCause(string from, string name, string desc = "")
     {
       this.name = name;
       this.desc = desc;
-      this.fromState = from;
+      this.otherState = from;
     }
   }
+
 }

--- a/SimulationEngine/StateTracker.cs
+++ b/SimulationEngine/StateTracker.cs
@@ -321,8 +321,9 @@ namespace SimulationTracking
                 retList.Add(item);
               }
               else if ((curIDType == EnModifiableTypes.mtState) &&
+                       ((!(item.eventData is StateCngEvent)) ||
                        (((StateCngEvent)item.eventData).evalCurOnInitial) &&
-                       (curStatesBS.HasCommonBits(item.relatedIDs)) &&
+                       (curStatesBS.HasCommonBits(item.relatedIDs))) &&
                        (item.eventData as CondBasedEvent).EventTriggered(curStatesBS, otherData, curTime, start3DTime, nextEvTime))
               {
                 retList.Add(item);
@@ -948,79 +949,115 @@ namespace SimulationTracking
       return finalStates;
     }
 
-    public List<List<int>> GetKeyStatePaths(AllStates allStates = null, Dictionary<string, SimulationEngine.ResultState> resMap = null)
+    public void GetKeyStatePaths(AllStates allStates = null, Dictionary<string, SimulationEngine.KeyStateResult> keyResMap = null, Dictionary<string, SimulationEngine.ResultState> otherResMap = null)
     {
-      List<List<int>> finalStates = new List<List<int>>();
-
       foreach (StatePath curStatePath in this.Values)
       {
-        if (curStatePath.state.stateType == EnStateType.stKeyState)
+        //get the paths for both key states and standard states
+        if (((curStatePath.state.stateType == EnStateType.stKeyState) && (keyResMap != null)) ||
+           ((curStatePath.state.stateType == EnStateType.stStandard) && (otherResMap != null)))
         {
-          if (resMap != null)
+          //make a new results item which will capture any looping items.
+          Dictionary<string, SimulationEngine.ResultState> curResDict = new Dictionary<string, SimulationEngine.ResultState>();
+
+          State curState = null;
+          State prevState = null;
+          State nextState = null;
+          
+          //bellow items declared here for efficiency
+          SimulationEngine.ResultState curResState = null;
+          SimulationEngine.EnterExitCause curCause = null;
+          SimulationEngine.ResultState updateItem = null;
+          string causeKey = "";
+          string evName = "";
+          string actName = "";
+
+          //this runs from the first to last item
+          for (int i = 0; i <= curStatePath.path.Count - 1; i++)
           {
-            State curFromState = null;
-            SimulationEngine.ResultState curState;
-            SimulationEngine.Cause curCause;
-            if (resMap.ContainsKey(curStatePath.state.name))
-            {
-              curState = resMap[curStatePath.state.name];
-            }
+            if (nextState != null)
+              curState = nextState;
             else
+              curState = allStates[curStatePath.path[i+1]];
+
+            if (i < (curStatePath.path.Count - 2))
+              nextState = allStates[curStatePath.path[i + 2]];
+            else if (i == (curStatePath.path.Count - 2))
+              nextState = curStatePath.state;
+            else
+              nextState = null;
+
+
+            //see if the item is already in the current result dictionary
+            if (!curResDict.TryGetValue(curState.name, out curResState))
             {
-              curState = new SimulationEngine.ResultState(curStatePath.state.name);
-              resMap.Add(curStatePath.state.name, curState);
+              curResState = new SimulationEngine.ResultState(curState.name);
+              curResDict.Add(curResState.name, curResState);
             }
 
-
-            for (int i = curStatePath.path.Count - 1; i >= 0; i--)
+            curResState.AddTime(curStatePath.times[i]);
+            //add where came from. if not at the beginning
+            if (prevState != null)
             {
-              curState.AddTime(curStatePath.times[i]);
-
-              if (i > 0)
+              evName = curStatePath.eventNames[i];
+              actName = curStatePath.actionNames[i];
+              causeKey = prevState.name + ", " + evName + ", " + actName;
+              if (!curResState.enterDict.TryGetValue(causeKey, out curCause))
               {
-                curFromState = allStates[curStatePath.path[i]];
-                string evName = curStatePath.eventNames[i];
-                string actName = curStatePath.actionNames[i];
-                string causeKey = curFromState.name + ", " + evName + ", " + actName;
+                curCause = new SimulationEngine.EnterExitCause(prevState.name, evName + " -> " + actName, causeKey);
+                curResState.enterDict.Add(curCause.desc, curCause);
+              }
 
-                if (curState.causeDict.ContainsKey(causeKey))
-                {
-                  curCause = curState.causeDict[causeKey];
-                }
-                else
-                {
-                  curCause = new SimulationEngine.Cause(evName + " -> " + actName, causeKey);
-                  curState.causeDict.Add(causeKey, curCause);
-                }
-
-                if (curCause.fromState == null)
-                {
-                  curCause.fromState = new SimulationEngine.ResultState(curFromState.name);
-                }
-
-                curState = curCause.fromState;
-              }              
+              curCause.cnt++;
             }
+
+            //add where going to, if not at the end
+            if (nextState != null)
+            {
+              evName = curStatePath.eventNames[i+1];
+              actName = curStatePath.actionNames[i+1];
+              causeKey = evName + ", " + actName + ", " + nextState.name;
+              if (!curResState.exitDict.TryGetValue(causeKey, out curCause))
+              {
+                curCause = new SimulationEngine.EnterExitCause(curState.name, evName + " -> " + actName, causeKey);
+                curResState.exitDict.Add(curCause.desc, curCause);
+              }
+
+              curCause.cnt++;
+            }
+
+            //prep for the next round
+            prevState = curState;
+
           }
 
-          curStatePath.path.Add(curStatePath.state.id);
-          finalStates.Add(curStatePath.path);
+          //collapse all the stats for this path 
+          foreach (var item in curResDict.Values)
+            item.Collapse();
+
+          //add cur run to either other results map or the key state results map
+          Dictionary<string, SimulationEngine.ResultState> addToRes = otherResMap;
+          if (curStatePath.state.stateType == EnStateType.stKeyState)
+          {
+            if (!keyResMap.ContainsKey(curStatePath.state.name))
+              keyResMap.Add(curStatePath.state.name, new SimulationEngine.KeyStateResult(curStatePath.state.name));
+
+            addToRes = keyResMap[curStatePath.state.name].pathsLookup;
+            //add the time for the key state overall result
+            keyResMap[curStatePath.state.name].AddTime(curStatePath.times[curStatePath.times.Count-1]);
+          }
+
+          foreach(var item in curResDict.Values)
+          {
+            if (!addToRes.TryGetValue(item.name, out updateItem))
+              addToRes.Add(item.name, item);
+            else
+              updateItem.Combine(item);
+
+          }
         }
       }
-
-      return finalStates;
     }
-
-    //public MyBitArray ToBitArray()
-    //{
-    //  MyBitArray retArray = new MyBitArray(this.Keys.Max() + 1);
-    //  foreach (int curKey in this.Keys.ToArray())
-    //  {
-    //    retArray[curKey] = true;
-    //  }
-
-    //  return retArray;
-    //}
   }
 
 
@@ -1981,26 +2018,9 @@ namespace SimulationTracking
     /// Get the paths of movement from start states to the key states for the simulation run
     /// </summary>
     /// <returns></returns>
-    public List<List<string>> GetKeyPaths(Dictionary<string, SimulationEngine.ResultState> resMap)
+    public void GetKeyPaths(Dictionary<string, SimulationEngine.KeyStateResult> resMap, Dictionary<string, SimulationEngine.ResultState> otherResMap)
     {
-      List<List<string>> retList = new List<List<string>>();
-
-      foreach (List<int> stPath in curStates.GetKeyStatePaths(allLists.allStates, resMap))
-      {
-        List<string> curList = new List<string>();
-        foreach (int id in stPath)
-        {
-          if (id > 0)
-          {
-
-            curList.Add(allLists.allStates[id].name);
-          }
-        }
-
-        retList.Add(curList);
-      }
-
-      return retList;
+      curStates.GetKeyStatePaths(allLists.allStates, resMap, otherResMap);
     }
 
     /// <summary>

--- a/SimulationEngine/StateTracker.cs
+++ b/SimulationEngine/StateTracker.cs
@@ -953,6 +953,8 @@ namespace SimulationTracking
     {
       foreach (StatePath curStatePath in this.Values)
       {
+        bool isKeyPath = (curStatePath.state.stateType == EnStateType.stKeyState);
+
         //get the paths for both key states and standard states
         if (((curStatePath.state.stateType == EnStateType.stKeyState) && (keyResMap != null)) ||
            ((curStatePath.state.stateType == EnStateType.stStandard) && (otherResMap != null)))
@@ -963,7 +965,7 @@ namespace SimulationTracking
           State curState = null;
           State prevState = null;
           State nextState = null;
-          
+
           //bellow items declared here for efficiency
           SimulationEngine.ResultState curResState = null;
           SimulationEngine.EnterExitCause curCause = null;
@@ -991,7 +993,7 @@ namespace SimulationTracking
             //see if the item is already in the current result dictionary
             if (!curResDict.TryGetValue(curState.name, out curResState))
             {
-              curResState = new SimulationEngine.ResultState(curState.name);
+              curResState = new SimulationEngine.ResultState(curState.name, isKeyPath);
               curResDict.Add(curResState.name, curResState);
             }
 
@@ -1019,7 +1021,7 @@ namespace SimulationTracking
               causeKey = evName + ", " + actName + ", " + nextState.name;
               if (!curResState.exitDict.TryGetValue(causeKey, out curCause))
               {
-                curCause = new SimulationEngine.EnterExitCause(curState.name, evName + " -> " + actName, causeKey);
+                curCause = new SimulationEngine.EnterExitCause(nextState.name, evName + " -> " + actName, causeKey);
                 curResState.exitDict.Add(curCause.desc, curCause);
               }
 

--- a/UnitTesting_Simulation/SimEngineTests.cs
+++ b/UnitTesting_Simulation/SimEngineTests.cs
@@ -447,7 +447,7 @@ namespace UnitTesting_Simulation
       Assert.True(TestRunSim(testRun));
 
       //Uncomment to update the validation files after they verified correct
-      CopyToValidated(dir, testName, optionsJ);
+      //CopyToValidated(dir, testName, optionsJ);
 
       //compare the test result and optionally the paths and json if assigned
       Compare(dir, testName, optionsJ);


### PR DESCRIPTION
Changed path results so that deep looping doesn't cause issues. Non-KeyState paths at the end of the simulation are also included in results. This should make building a Sankey diagram much easier.