### PR TITLE
Fixed component logic event bug

### DIFF
--- a/Emrald_Site/EditForms/EventEditor.js
+++ b/Emrald_Site/EditForms/EventEditor.js
@@ -112,6 +112,9 @@ function ValidateData() {
     if (scope.typeOption.value === 'et3dSimEv' && !scope.variable) {
         return "Please specify an External Sim Variable before saving the event.";
     }
+    if (scope.typeOption.value === 'etComponentLogic' && !scope.logicTop) {
+        return "Please specify a top logic gate before saving the event.";
+    }
     return "";
 }
 
@@ -530,7 +533,9 @@ function GetDataObject() {
             break;
         case "etComponentLogic":
             dataObj.onSuccess = scope.onSuccess;
-            dataObj.logicTop = scope.logicTop.name;
+            if (scope.logicTop) {
+                dataObj.logicTop = scope.logicTop.name;
+            }
             break;
         case "etTimer":
             dataObj.useVariable = scope.data.timer.useVariable;


### PR DESCRIPTION
Fixes #94 

The event editor now displays an error message instead of completely breaking when trying to save a component logic event with no selected top gate.