### PR TITLE
Fixed sim crashing if no ext sim is selected

### DIFF
--- a/EMRALD_Sim/FormMain.cs
+++ b/EMRALD_Sim/FormMain.cs
@@ -997,7 +997,9 @@ namespace EMRALD_Sim
         }
       }
 
-      lbExtSimLinks.SetItemCheckState(lbExtSimLinks.SelectedIndex, ck);
+      if (lbExtSimLinks.SelectedIndex > -1) {
+        lbExtSimLinks.SetItemCheckState(lbExtSimLinks.SelectedIndex, ck);
+      }
     }
 
     private void defaultLoadToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #54 

I just added an if statement around the Ext Sim selection handler to make sure the selected index is valid.