### PR TITLE
Disabled type & import options when a template is selected

### DIFF
--- a/Emrald_Site/EditForms/DiagramEditor.html
+++ b/Emrald_Site/EditForms/DiagramEditor.html
@@ -47,7 +47,7 @@
             <div ng-if="createDiagram"><b>Create New Diagram<br /></b><br /></div>
             <div style="display:table-row">
                 <div style="display:table-cell">Type:</div>
-                <select style="display:table-cell;width: 130px;float:left" id="TypeOption" ng-model="diagramType" ng-options="dt.name for dt in diagramTypes" name="Type" ng-disabled="data.importedContent"></select>
+                <select style="display:table-cell;width: 130px;float:left" id="TypeOption" ng-model="diagramType" ng-options="dt.name for dt in diagramTypes" name="Type" ng-disabled="data.importedContent || data.templateIsSelected"></select>
             </div>
             <div ng-if="showNewTypeEditor">
                 <div style="display:table-row">
@@ -68,7 +68,7 @@
 
             <div ng-if="createDiagram"><br />
                 <div class="separator">OR</div><br /><b>Import Diagram: </b>
-                <input type="button" value="Choose File" onclick="mergeIntoCurrentProject()" />
+                <input type="button" value="Choose File" onclick="mergeIntoCurrentProject()" ng-disabled="data.templateIsSelected" />
                 <span><i>{{data.fileName}}</i><input ng-if="data.fileName" type="button" value="X" title="Remove File" onclick="removeFile()"/></span>
                 <br />
                 <input type="checkbox" ng-model="data.forceMerge" /> Force conflict resolution

--- a/Emrald_Site/EditForms/DiagramEditor.html
+++ b/Emrald_Site/EditForms/DiagramEditor.html
@@ -47,7 +47,14 @@
             <div ng-if="createDiagram"><b>Create New Diagram<br /></b><br /></div>
             <div style="display:table-row">
                 <div style="display:table-cell">Type:</div>
-                <select style="display:table-cell;width: 130px;float:left" id="TypeOption" ng-model="diagramType" ng-options="dt.name for dt in diagramTypes" name="Type" ng-disabled="data.importedContent || data.templateIsSelected"></select>
+                <div ng-if="data.templateIsSelected">
+                    <select style="display:table-cell;width: 130px;float:left" disabled>
+                        <option>Set by template</option>
+                    </select>
+                </div>
+                <div ng-if="!data.templateIsSelected">
+                    <select style="display:table-cell;width: 130px;float:left" id="TypeOption" ng-model="diagramType" ng-options="dt.name for dt in diagramTypes" name="Type" ng-disabled="data.importedContent"></select>
+                </div>
             </div>
             <div ng-if="showNewTypeEditor">
                 <div style="display:table-row">

--- a/Emrald_Site/EditForms/DiagramEditor.js
+++ b/Emrald_Site/EditForms/DiagramEditor.js
@@ -310,11 +310,14 @@ diagramModule.controller('diagramController', function ($scope, $timeout) {
     }
 
     $scope.selectedTemplate = null;
+    $scope.data.templateIsSelected = false;
     $scope.chooseTemplate = function (index) {
         if ($scope.selectedTemplate === index) {
             $scope.selectedTemplate = null;
+            $scope.data.templateIsSelected = false;
         } else {
             $scope.selectedTemplate = index;
+            $scope.data.templateIsSelected = true;
         }
     };
 


### PR DESCRIPTION
Closes #142 

Disables the diagram type selection & import diagram button when a template is selected, as the template will override the type and importing is not valid.