### PR TITLE
Fixed transition actions not being editable

### DIFF
--- a/Emrald_Site/EditForms/ActionEditor.js
+++ b/Emrald_Site/EditForms/ActionEditor.js
@@ -237,7 +237,7 @@ function OnLoad(dataObj) {
                             scope.data.transitions.push({ checked: false, To_State: aState.toState, Probability: aState.prob.toString(), varProb: aState.varProb, failDesc: aState.failDesc, remaining: false, });
                         }
                         else {
-                            scope.data.transitions.push({ checked: false, To_State: aState.toState, Probability: '0', varProb: aState.varProb, failDesc: aState.failDesc, remaining: true, });
+                            scope.data.transitions.push({ checked: false, To_State: aState.toState, Probability: '0', varProb: aState.varProb, failDesc: aState.failDesc, remaining: scope.data.transitions.length === 0, });
                         }
                     });
                 }


### PR DESCRIPTION
Fixes #198 

When a transition action was connected with 2 or more arrows, the edit form would disable all of the inputs. This commit changes the form behavior by setting the first added arrow to "remaining", and subsequent arrows to 0, which makes the form work as expected.