### PR TITLE
Fixed z-index to be above the overlay

### DIFF
--- a/Emrald_Site/index.cshtml
+++ b/Emrald_Site/index.cshtml
@@ -73,7 +73,7 @@
     <div id="SidePanelContainer" style="position: absolute; top: 76px; bottom: 2px; background-color: teal; margin: 2px; float: left; width: 170px;">
         <div id="SidePanel"></div>
     </div>
-    <div id="ContentPanel" style="position: absolute; left: 180px; top: 76px; bottom: 0px; right: 0px; margin: 2px; clip: rect(auto, auto, auto, auto); z-index: 1;">
+    <div id="ContentPanel" style="position: absolute; left: 180px; top: 76px; bottom: 0px; right: 0px; margin: 2px; clip: rect(auto, auto, auto, auto); z-index: 1002;">
     </div>
 </div>
 

--- a/Emrald_Site/index.html
+++ b/Emrald_Site/index.html
@@ -68,7 +68,7 @@
     <div id="SidePanelContainer" style="position: absolute; top: 76px; bottom: 2px; background-color: teal; margin: 2px; float: left; width: 170px;">
         <div id="SidePanel"></div>
     </div>
-    <div id="ContentPanel" style="position: absolute; left: 180px; top: 76px; bottom: 0px; right: 0px; margin: 2px; clip: rect(auto, auto, auto, auto); z-index: 1;">
+    <div id="ContentPanel" style="position: absolute; left: 180px; top: 76px; bottom: 0px; right: 0px; margin: 2px; clip: rect(auto, auto, auto, auto); z-index: 1002;">
     </div>
 </div>
 


### PR DESCRIPTION
The z-index I set in #211 fixed that bug, but now when creating a new project, the windows appear below an overlay and can't be interacted with, so this sets the windows to always appear at the very top of UI.