### PR TITLE
Add the ability to import a diagram from create new diagram form

### DIFF
--- a/Emrald-UI/src/components/common/FileUploadComponent.tsx
+++ b/Emrald-UI/src/components/common/FileUploadComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import Button from '@mui/material/Button/Button';
 import FileUploadIcon from '@mui/icons-material/FileUpload';
 import { styled } from '@mui/material/styles';
@@ -19,39 +19,34 @@ const VisuallyHiddenInput = styled('input')({
 
 interface FileUploadComponentProps {
   label: string;
-  file: any;
-  setFile: (value: any) => void;
   disabled?: boolean;
+  setFile: (value: File | null) => void;
+  clearFile?: () => void;
 }
 
 const FileUploadComponent: React.FC<FileUploadComponentProps> = ({
   label,
-  file,
+  disabled,
   setFile,
-  disabled
+  clearFile
 }) => {
+  const [uploadedContent, setUploadedContent] = React.useState<File | null>();
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files ? e.target.files[0] : null;
-    if (file) {
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        if (event.target && typeof event.target.result === 'string') {
-          try {
-            console.log(event.target.result);
-          } catch (error) {
-            console.error("Error parsing JSON file:", error);
-          }
-        }
-      };
-      reader.readAsText(file);
-      setFile(file);
-    } else {
-      setFile(null);
-    }
+    setFile(file);
+    setUploadedContent(file);
   };
 
   const handleClear = () => {
     setFile(null);
+    setUploadedContent(null);
+    if (clearFile) {
+      clearFile();
+    }
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
   };
 
   return (
@@ -67,15 +62,16 @@ const FileUploadComponent: React.FC<FileUploadComponentProps> = ({
       >
         {label}
         <VisuallyHiddenInput
+          ref={inputRef}
           type="file"
           onChange={handleFileChange}
         />
       </Button>
-      {file && (
-        <Typography sx={{ ml: 3, fontSize: 18 }}>{file.name}</Typography>
+      {uploadedContent && (
+        <Typography sx={{ ml: 3, fontSize: 18 }}>{uploadedContent.name}</Typography>
       )}
       {
-        file && (
+        uploadedContent && (
           <IconButton
             aria-label="close"
             onClick={handleClear}

--- a/Emrald-UI/src/components/forms/ActionForm/FormFieldsByType/RunApplication/CustomForms/MAAP/maap.tsx
+++ b/Emrald-UI/src/components/forms/ActionForm/FormFieldsByType/RunApplication/CustomForms/MAAP/maap.tsx
@@ -17,9 +17,9 @@ const MAAP = () => {
 
 
   const [exePath, setExePath] = useState(formData?.exePath || '');
-  const [parameterFile, setParameterFile] = useState('');
+  const [parameterFile, setParameterFile] = useState<File | null>();
   const [parameterPath, setParameterPath] = useState(formData?.parameterPath || '');
-  const [inputFile, setInputFile] = useState('');
+  const [inputFile, setInputFile] = useState<File | null>();
   const [inputPath, setInputPath] = useState(formData?.inputPath || '');
   const [currentTab, setCurrentTab] = React.useState(0);
 
@@ -64,7 +64,7 @@ const MAAP = () => {
             setValue={setExePath} 
           />
 
-          <FileUploadComponent label="Parameter File" file={parameterFile} setFile={setParameterFile}/>
+          <FileUploadComponent label="Parameter File" setFile={setParameterFile}/>
 
           <TextFieldComponent 
             value={parameterPath} 
@@ -72,7 +72,7 @@ const MAAP = () => {
             setValue={setParameterPath} 
           />
 
-          <FileUploadComponent label="Input File" file={inputFile} setFile={setInputFile}/>
+          <FileUploadComponent label="Input File" setFile={setInputFile}/>
 
           <TextFieldComponent 
             value={inputPath} 

--- a/Emrald-UI/src/components/forms/ImportForm/ImportForm.tsx
+++ b/Emrald-UI/src/components/forms/ImportForm/ImportForm.tsx
@@ -81,7 +81,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.Diagram,
         displayType: 'Diagram',
-        locked: false,
+        locked: !diagramList.value.some(item => item.name === diagram.name),
         oldName: diagram.name,
         newName: diagram.name,
         action: 'rename',
@@ -94,7 +94,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.LogicNode,
         displayType: 'Logic Node',
-        locked: false,
+        locked: !logicNodeList.value.some(item => item.name === logicNode.name),
         oldName: logicNode.name,
         newName: logicNode.name,
         action: 'rename',
@@ -107,7 +107,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.ExtSim,
         displayType: 'External Sim',
-        locked: false,
+        locked: !extSimList.value.some(item => item.name === extSim.name),
         oldName: extSim.name,
         newName: extSim.name,
         action: 'rename',
@@ -120,7 +120,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.Action,
         displayType: 'Action',
-        locked: false,
+        locked: !actionsList.value.some(item => item.name === action.name),
         oldName: action.name,
         newName: action.name,
         action: 'rename',
@@ -133,7 +133,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.Event,
         displayType: 'Event',
-        locked: false,
+        locked: !eventsList.value.some(item => item.name === event.name),
         oldName: event.name,
         newName: event.name,
         action: 'rename',
@@ -146,7 +146,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.State,
         displayType: 'State',
-        locked: false,
+        locked: !statesList.value.some(item => item.name === state.name),
         oldName: state.name,
         newName: state.name,
         action: 'rename',
@@ -159,7 +159,7 @@ const ImportForm: React.FC<ImportDiagramFormProps> = ({ importedData, fromTempla
       items.push({
         type: MainItemTypes.Variable,
         displayType: 'Variable',
-        locked: false,
+        locked: !variableList.value.some(item => item.name === variable.name),
         oldName: variable.name,
         newName: variable.name,
         action: 'rename',

--- a/Emrald-UI/src/components/forms/TemplateForm/useTemplateForm.tsx
+++ b/Emrald-UI/src/components/forms/TemplateForm/useTemplateForm.tsx
@@ -26,7 +26,7 @@ interface TemplatedItem {
 }
 
 export const useTemplateForm = (templatedData: EMRALD_Model) => {
-  const {groups, templatesList, temporaryTemplates, createTemplate, findGroupHierarchyByGroupName} = useTemplateContext();
+  const {groups, temporaryTemplates, createTemplate, findGroupHierarchyByGroupName} = useTemplateContext();
   const [findValue, setFindValue] = useState<string>('');
   const [replaceValue, setReplaceValue] = useState<string>('');
   const [templatedItems, setTemplatedItems] = useState<TemplatedItem[]>([]);


### PR DESCRIPTION
Changes to make it so a user can import a diagram from the create new diagram form. All imported diagrams must go through the conflict resolution check before adding.