### PR TITLE
Docs build fix

### DIFF
--- a/Emrald-UI/package.json
+++ b/Emrald-UI/package.json
@@ -39,7 +39,6 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
-    "@adobe/jsonschema2md": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",

--- a/emrald-docs/package.json
+++ b/emrald-docs/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@adobe/jsonschema2md": "^6.0.0",
     "cross-env": "^7.0.3",
     "vuepress": "^1.5.3"
   }


### PR DESCRIPTION
Moves the dev dependency from emrald ui directory to the emrald-docs directory. 