### PR TITLE
Highlight edges on click

### DIFF
--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/Edges/EventActionEdge.ts
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/Edges/EventActionEdge.ts
@@ -82,9 +82,6 @@ const getEventActionEdges = (
               stroke: `${action.moveFromCurrent ? '#b1b1b7' : 'green'}`,
               strokeDasharray: `${action.moveFromCurrent ? '' : 5}`
             },
-            // labelStyle: {
-            //   transform: `translateY(${index % 2 === 0 ? '-20px' : '0px'})`,
-            // },
             markerEnd: { 
               type: MarkerType.ArrowClosed, 
               width: 25, 

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/EmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/EmraldDiagram.tsx
@@ -33,6 +33,8 @@ const EmraldDiagram: React.FC<EmraldDiagramProps> = ({ diagram }) => {
     getStateNodes,
     onNodesChange,
     onEdgesChange,
+    onEdgeClick,
+    onPaneClick,
     onNodeDragStop,
     onConnect,
     onNodeDoubleClick,
@@ -73,13 +75,14 @@ const EmraldDiagram: React.FC<EmraldDiagramProps> = ({ diagram }) => {
             edges={edges}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
+            onEdgeClick={onEdgeClick}
             onConnect={onConnect}
             onPaneContextMenu={onPaneContextMenu}
             onNodeContextMenu={onNodeContextMenu}
             onNodeDoubleClick={onNodeDoubleClick}
             onEdgeContextMenu={(event, edge) => onEdgeContextMenu(event, edge, edges)}
             onEdgeUpdate={onEdgeUpdate}
-            onPaneClick={() => closeContextMenu()}
+            onPaneClick={(e) => { closeContextMenu(); onPaneClick(e); }}
             connectionLineComponent={CustomConnectionLine}
             onNodeDragStop={onNodeDragStop}
             isValidConnection={isValidConnection}

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
@@ -637,9 +637,9 @@ const useContextMenu = (getStateNodes?: () => void, setEdges?: (edges: Edge[]) =
   // * Removes an edge connection
   const deleteEdge = (edge: Edge, edges: Edge[]) => {
     if (edge && edges && setEdges) {
-      const actionId = edge.sourceHandle?.split('-')[3];
+      const actionId = edge.sourceHandle?.split('*')[1];
       const actionToUpdate = actionId ? getActionByActionId(actionId) : undefined;
-      const targetState = getStateByStateId(edge.target?.split('-')[1]);
+      const targetState = getStateByStateId(edge.target);
 
       if (!actionToUpdate?.newStates) {
         return;

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
@@ -71,6 +71,32 @@ const useEmraldDiagram = () => {
     });
   };
 
+  const onEdgeClick = (_event: any, edge: Edge) => {
+    // Highlight selected edge so its easier to see its connection and label
+    setEdges((eds) =>
+      eds.map((e) => {
+        if (e.id === edge.id) {
+          return {
+            ...e,
+            style: { ...e.style, stroke: '#e3961c' },
+            labelStyle: { ...e.labelStyle, fill: '#e3961c', fontWeight: 'bold', transform: 'translateY(-10px)' },
+          };
+        } else {
+          return {
+            ...e,
+            style: { ...e.style, stroke: '#b1b1b7' },
+            labelStyle: { ...e.labelStyle, fill: 'transparent' },
+          };
+        }
+      })
+    );
+  };
+
+  const onPaneClick = (_event: any) => {
+    // reset edge color when the user clicks away
+    getEdges(nodes);
+  };
+
   // Double Clicks
   const onNodeDoubleClick = (_event: any, node: Node) => {
     if (node.data.state) {
@@ -276,6 +302,8 @@ const useEmraldDiagram = () => {
     onNodesChange,
     onEdgesChange,
     onEdgeUpdate,
+    onEdgeClick,
+    onPaneClick,
     onConnect,
     onNodeDoubleClick,
     onEventDoubleClick,

--- a/Emrald-UI/src/components/forms/ActionForm/ActionFormContext.tsx
+++ b/Emrald-UI/src/components/forms/ActionForm/ActionFormContext.tsx
@@ -159,7 +159,7 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
 
   const handleMutuallyExclusiveChange = (value: boolean) => {
     newStateItems.forEach((newStateItem) => {
-      checkProbability(newStateItem, value);
+      checkProbability(newStateItem, newStateItems, value);
       if (value === false) {
         if (newStateItem.prob === -1) {
           newStateItem.remaining = false;
@@ -190,7 +190,7 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
     return nameExists;
   };
 
-  const checkProbability = (updatedItem: NewStateItem, updatedMutuallyExclusive?: boolean, updatedRemaining?: boolean | undefined) => {
+  const checkProbability = (updatedItem: NewStateItem, updateItems: NewStateItem[], updatedMutuallyExclusive?: boolean, updatedRemaining?: boolean | undefined) => {
     if (!updatedItem.prob) {
       setErrorIds((prevErrorItemIds) => new Set([...prevErrorItemIds, updatedItem.id]));
       setErrorMessage('Must contain a value');
@@ -198,12 +198,14 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
     }
   
     if (updatedMutuallyExclusive !== undefined ? updatedMutuallyExclusive : mutuallyExclusive) {
-      const totalProb = newStateItems.reduce((acc, item) => {
+      const totalProb = updateItems.reduce((acc, item) => {
           return item.prob === -1 ? acc : acc + Number(item.prob);
         }, 0);
         let remainingProb: number;
 
-        if (updatedRemaining !== undefined && updatedRemaining === true) {
+        const hasRemainingTrue = updateItems.some((item) => item.remaining === true);
+
+        if (updatedRemaining!== undefined && updatedRemaining === true || hasRemainingTrue) {
           remainingProb = 1 - totalProb;
         } else {
           remainingProb = 0;
@@ -222,7 +224,7 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
       const probValue = Number(updatedItem.prob);
       if (probValue > 1) {
         setErrorIds((prevErrorItemIds) => new Set([...prevErrorItemIds, updatedItem.id]));
-        setErrorMessage('Probabilities must be greater than 0 andnot exceed 1');
+        setErrorMessage('Probabilities must be greater than 0 and not exceed 1');
         setHasError(true);
       } else {
         setErrorIds((prevErrorItemIds) => new Set([...prevErrorItemIds].filter((id) => id !== updatedItem.id)));
@@ -399,7 +401,7 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
           return item;
         });
 
-        checkProbability(updatedItem);
+        checkProbability(updatedItem, updatedItems);
         return updatedItems;
       });
     } 
@@ -429,7 +431,7 @@ const ActionFormContextProvider: React.FC<PropsWithChildren> = ({ children }) =>
       ...item,
       remaining: event.target.checked,
       prob: event.target.checked ? -1 : 0.0,
-    }, undefined, event.target.checked);
+    }, updatedItems);
   };
 
   const handleProbTypeChange = (event: React.ChangeEvent<HTMLInputElement>, item: NewStateItem) => {

--- a/Emrald-UI/src/components/forms/ActionForm/ActionToStateTable.tsx
+++ b/Emrald-UI/src/components/forms/ActionForm/ActionToStateTable.tsx
@@ -21,7 +21,8 @@ import {
   Typography,
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { useActionFormContext } from './ActionFormContext';
+import { NewStateItem, useActionFormContext } from './ActionFormContext';
+import { scientificToNumeric } from '../../../utils/util-functions';
 
 export const StyledTableCell = styled(TableCell)(({ theme }) => ({
   [`&.${tableCellClasses.head}`]: {
@@ -76,19 +77,26 @@ const ActionToStateTable: React.FC = () => {
       return 'Calculated at runtime';
     } else {
       // Check if all prob values are valid numbers
-      const allProbValuesAreNumbers = newStateItems.every(
-        (item) => typeof item.prob === 'number' && !isNaN(item.prob)
+      const convertedProbValues = newStateItems.map((item: NewStateItem) => {
+          if (typeof item.prob === 'string') {
+            return scientificToNumeric(item.prob);
+          } else {
+            return item.prob
+          }
+        }
+      )
+      const allProbValuesAreNumbers = convertedProbValues.every(
+        (item) => typeof item === 'number' && !isNaN(item)
       );
   
       if (!allProbValuesAreNumbers) {
         return 'Unable to calculate';
       }
+      const sumOfProbs = convertedProbValues
+        .filter((item) => item !== -1)
+        .reduce((acc: number, item) => acc + (item as number), 0);
   
-      const sumOfProbs = newStateItems
-        .filter((item) => typeof item.prob === 'number' && item.prob !== -1)
-        .reduce((acc, item) => acc + (item.prob as number), 0);
-  
-      const remainingProb = 1 - sumOfProbs;
+      let remainingProb = 1 - sumOfProbs;
       if (remainingProb > 1) { 
         return 'Invalid Probability';
       }


### PR DESCRIPTION
- Make it so edges that are clicked on are highlighted so its easier to see line connections and labels.
- Deleting a edge via right click on the diagram was broken. It has now been fixed and works as expected.
- Action to state table now correctly checks the values and handles the remaining probability calculation better.