### PR TITLE
Make it so gate type uses correct value when editing

### DIFF
--- a/Emrald-UI/src/components/diagrams/LogicTreeDiagram/useLogicTreeDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/LogicTreeDiagram/useLogicTreeDiagram.tsx
@@ -367,7 +367,7 @@ const useLogicNodeTreeDiagram = () => {
             action: () =>
               addWindow(
                 `Edit Gate Node: ${label}`,
-                <LogicNodeForm logicNodeData={logicNode} editing={true} />,
+                <LogicNodeForm logicNodeData={logicNode} gateType={logicNode.gateType} editing={true} />,
               ),
             isDivider: true,
           },


### PR DESCRIPTION
Make it so when editing a logic node that the gate type is passed as a prop and displays correctly in the edit form