### PR TITLE
Fix copying node then deleting then pasting issue.

### DIFF
--- a/Emrald-UI/src/components/drag-and-drop/LogicTreeNodeDroppable.tsx
+++ b/Emrald-UI/src/components/drag-and-drop/LogicTreeNodeDroppable.tsx
@@ -33,7 +33,7 @@ const LogicTreeNodeDropTarget: React.FC<PropsWithChildren<LogicNodeDroppableItem
     useLogicNodeContext();
   const newGateNode = useSignal<LogicNode>(emptyLogicNode);
   // const [compDiagram, setCompDiagram] = useState<boolean>(false);
-  const { couldCreateInifinteLoop } = useLogicNodeTreeDiagram();
+  const { couldCreateInfiniteLoop } = useLogicNodeTreeDiagram();
   const resetNewNode = () => {
     newGateNode.value = emptyLogicNode;
   };
@@ -62,7 +62,7 @@ const LogicTreeNodeDropTarget: React.FC<PropsWithChildren<LogicNodeDroppableItem
         updateLogicNode(logicNode); // Update the dropped node with the new compChildren
       } else if (item.objType === 'LogicNode') {
         const logicNode = getLogicNodeByName(node); // Get the info of the logic node to be updated
-        if (couldCreateInifinteLoop(logicNode, item.name)) {
+        if (couldCreateInfiniteLoop(logicNode, item.name)) {
           console.log('Alert: This node is already in the logic tree either as a child or parent');
           return;
         }


### PR DESCRIPTION
Resolves #429 & #430

* Fixes issue where a blank node was being created when copying, deleting, and then pasting the node.
* Moves check to see if there is a circular reference to cover both paste and paste (as new) options.