### PR TITLE
Fixed state change event bug.

### DIFF
--- a/EMRALD.sln
+++ b/EMRALD.sln
@@ -13,8 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimulationEngine", "Simulat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EMRALD_Sim", "EMRALD_Sim\EMRALD_Sim.csproj", "{B6F47973-B227-4825-BB2D-B995F5FE2E9C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Testing", "VandV_Testing\Testing.csproj", "{43990779-63AB-4896-8AEE-7B06F7BC6B0B}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XmppClient", "XmppClient\XmppClient.csproj", "{8846DEF8-E1EB-408E-9316-D85E273E7E09}"
 EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Emrald_Site", "Emrald_Site\", "{6A02BDBB-CBDA-4ADF-81DA-4499666F7C2B}"
@@ -23,7 +21,7 @@ Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Emrald_Site", "Emrald_Site\
 		SccAuxPath = "SAK"
 		SccLocalPath = "SAK"
 		SccProvider = "SAK"
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.8"
+		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.5.2"
 		Debug.AspNetCompiler.VirtualPath = "/localhost_56455"
 		Debug.AspNetCompiler.PhysicalPath = "Emrald_Site\"
 		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_56455\"
@@ -45,23 +43,25 @@ EndProject
 Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Emrald-UI", "Emrald-UI\", "{DBFECD62-5F5A-4A30-BCC9-63FA05E10638}"
 	ProjectSection(WebsiteProperties) = preProject
 		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.8"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_51567"
+		Debug.AspNetCompiler.VirtualPath = "/localhost_56867"
 		Debug.AspNetCompiler.PhysicalPath = "Emrald-UI\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_51567\"
+		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_56867\"
 		Debug.AspNetCompiler.Updateable = "true"
 		Debug.AspNetCompiler.ForceOverwrite = "true"
 		Debug.AspNetCompiler.FixedNames = "false"
 		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_51567"
+		Release.AspNetCompiler.VirtualPath = "/localhost_56867"
 		Release.AspNetCompiler.PhysicalPath = "Emrald-UI\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_51567\"
+		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_56867\"
 		Release.AspNetCompiler.Updateable = "true"
 		Release.AspNetCompiler.ForceOverwrite = "true"
 		Release.AspNetCompiler.FixedNames = "false"
 		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "51567"
+		VWDPort = "56867"
 		SlnRelativePath = "Emrald-UI\"
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testing", "VandV_Testing\Testing.csproj", "{AD1C0DC0-E23B-AA72-3FB8-B3241476958B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,10 +89,6 @@ Global
 		{B6F47973-B227-4825-BB2D-B995F5FE2E9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B6F47973-B227-4825-BB2D-B995F5FE2E9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B6F47973-B227-4825-BB2D-B995F5FE2E9C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{43990779-63AB-4896-8AEE-7B06F7BC6B0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{43990779-63AB-4896-8AEE-7B06F7BC6B0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{43990779-63AB-4896-8AEE-7B06F7BC6B0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{43990779-63AB-4896-8AEE-7B06F7BC6B0B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8846DEF8-E1EB-408E-9316-D85E273E7E09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8846DEF8-E1EB-408E-9316-D85E273E7E09}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8846DEF8-E1EB-408E-9316-D85E273E7E09}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -105,6 +101,10 @@ Global
 		{DBFECD62-5F5A-4A30-BCC9-63FA05E10638}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DBFECD62-5F5A-4A30-BCC9-63FA05E10638}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{DBFECD62-5F5A-4A30-BCC9-63FA05E10638}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{AD1C0DC0-E23B-AA72-3FB8-B3241476958B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD1C0DC0-E23B-AA72-3FB8-B3241476958B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD1C0DC0-E23B-AA72-3FB8-B3241476958B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD1C0DC0-E23B-AA72-3FB8-B3241476958B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SimulationDAL/Events.cs
+++ b/SimulationDAL/Events.cs
@@ -267,8 +267,6 @@ namespace SimulationDAL
         changed = new MyBitArray(curStates.Length);
       }
       
-      //changed.OrApply(((ChangedIDs)otherData).stateIDs_BS);
-
       
       if (_relatedIDsBitSet.Length < curStates.Length)
         _relatedIDsBitSet.Length = curStates.Length;
@@ -277,32 +275,25 @@ namespace SimulationDAL
       {
         changed = new MyBitArray(curStates.Length);
       }
-      //MyBitArray changed = new MyBitArray(_relatedIDsBitSet);
+      
+      //find the changed items that are appicable for entry or exit
       if (!ifInState)
       {
-        //find in changed and not in current (xor then and with origional)
-        MyBitArray compareBits = ((ChangedIDs)otherData).stateIDs_BS.Xor(curStates).And(((ChangedIDs)otherData).stateIDs_BS);
-        changed.OrApply(compareBits);
+        //find in changed and not in current
+        changed = ((ChangedIDs)otherData).stateIDs_BS.And(curStates.Not());
       }
-      else
-        changed.OrApply(((ChangedIDs)otherData).stateIDs_BS);
+      else //in the specified state
+      {
+        //find if in changedID and in current states
+        changed = ((ChangedIDs)otherData).stateIDs_BS.And(curStates);
+      }
 
+      //make changed are also in the related items
       MyBitArray cngAndRelated = changed.And(_relatedIDsBitSet);
       if (this.allItems)
         return (cngAndRelated.BitCount() == relatedIDs.Count());
       else
         return cngAndRelated.BitCount() > 0;
-
-      //if (ifInState) //We are looking for an item in the list to trigger us       
-      //{
-      //  //curStates must contain all of the items in relatedIDs
-      //  return (both.BitCount() == _relatedIDsBitSet.BitCount());
-      //}
-      //else //Don't want to be in the specified states
-      //{
-      //  //curStates must contain none of the items in relatedIDs
-      //  return (both.BitCount() == 0);
-      //}
     }
 
     public override void LookupRelatedItems(EmraldModel all, EmraldModel addToList)

--- a/SimulationDAL/SetupNotes.txt
+++ b/SimulationDAL/SetupNotes.txt
@@ -1,3 +1,4 @@
 Make sure the MakeJSFromTS.bat and ScripttoExportCS.bat are both executed on the new build of this project. 
+You must have EMRALD-UI compiled an do npm install from that folder before the bat files can run.
 This is done by adding the following line to the pre-build event: call "$(ProjectDir)../Emrald-UI/src/utils/MakeJSFromTS.bat" & call "$(ProjectDir)../Emrald-UI/src/utils/ScriptToExportForCSharp.bat" "$(ProjectDir)/Upgrade/UI_UpgradeBundle.js"
 The upgrade of a project uses the same code as the UI.

--- a/SimulationEngine/StateTracker.cs
+++ b/SimulationEngine/StateTracker.cs
@@ -213,6 +213,7 @@ namespace SimulationTracking
 
               case EnEventType.etComponentLogic:
                 curIDType = EnModifiableTypes.mtState;
+                otherData = item.eventStateActions.statesAndActions.Keys.First();
                 break;
 
               default:

--- a/VandV_Testing/TestingFiles/CompareFiles/Event_1TransitionInOutTest_res.txt
+++ b/VandV_Testing/TestingFiles/CompareFiles/Event_1TransitionInOutTest_res.txt
@@ -2,9 +2,9 @@ Simulation = EventsTest
 Runtime = 00.00:00:00
 Runs = 100 of 100
 
-MoveInDetected Occurred 100 times, Probability =1, MeanTime = 00.00:05:00 +/- 00.00:00:00.00
+MoveOutDetected Occurred 100 times, Probability =1, MeanTime = 00.00:00:00 +/- 00.00:00:00.00
 
-MoveOutDetected Occurred 100 times, Probability =1, MeanTime = 00.00:10:00 +/- 00.00:00:00.00
+MoveInDetected Occurred 100 times, Probability =1, MeanTime = 00.00:05:00 +/- 00.00:00:00.00
 ---------------------------
 - End Sim Variable Values -
 ---------------------------


### PR DESCRIPTION
#### Description
The state change events could be triggered on the opposite criteria, as well as their correct criteria when there was a loop. example - On-Exit was doing it on-entry also.

#### Related Issue
#446 

#### Changes Made
List the specific changes made in this PR:
changed Events.cs code StateCngEvent.EventTriggered
corrected the bitset logic.

#### Type of Change
Select the type of change your PR introduces:
- [ ] Bug fix (fixes an issue)

#### Checklist
Please ensure the following are completed:
- [ x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)
NA

#### Additional Notes
na
