### PR TITLE
Fixed merge project bug

### DIFF
--- a/Emrald-UI/src/components/layout/Header/menuOptions.tsx
+++ b/Emrald-UI/src/components/layout/Header/menuOptions.tsx
@@ -71,7 +71,7 @@ export const projectOptions = (setFileName?: (name: string) => void): MenuOption
       // Create a new file input element
       const fileInput = document.createElement('input');
       fileInput.type = 'file'; // Set input type to file
-      fileInput.accept = '.json'; // Specify accepted file types as JSON
+      fileInput.accept = '.json,.emrald'; // Specify accepted file types as JSON
       fileInput.style.display = 'none'; // Hide the file input element
 
       // Function to handle file selection
@@ -89,7 +89,7 @@ export const projectOptions = (setFileName?: (name: string) => void): MenuOption
           try {
             const parsedContent = JSON.parse(content);
             if (parsedContent && parsedContent.hasOwnProperty('emraldVersion')) {
-              mergeNewData(content);
+              mergeNewData(parsedContent);
             } else {
               const upgradedModel = upgradeModel(content);
               if (upgradedModel) {


### PR DESCRIPTION
#### Description

Fixes an issue with merging projects. 

#### Changes Made

- Changed open file dialog to accept both .json and .emrald files
- The file contents were being parsed as JSON, but the unparsed string was being passed to the merge function instead of the JSON object, resulting in an error when the merge function tried to access the DiagramList. This fix passes the parsed object to resolve this bug.

#### Type of Change

- [x] Bug fix (fixes an issue)

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
