### PR TITLE
Fixed ResizeObserver error crashing the page

### DIFF
--- a/Emrald-UI/src/hooks/useErrorBoundary.tsx
+++ b/Emrald-UI/src/hooks/useErrorBoundary.tsx
@@ -6,8 +6,10 @@ function useErrorBoundary() {
 
   useEffect(() => {
     const handleWindowError = (event: ErrorEvent) => {
-      setHasError(true);
-      setErrorMessage(event.message);
+      if (event.message !== 'ResizeObserver loop completed with undelivered notifications.') {
+        setHasError(true);
+        setErrorMessage(event.message);
+      }
     };
 
     window.addEventListener('error', handleWindowError);


### PR DESCRIPTION
#### Description

"ResizeObserver loop completed with undelivered notifications" is a warning built in to JavaScript that catches and stops potential infinite loops when resizing elements. When resizing states, this warning would get caught by the global error boundary and crash the page as if it was a critical error, however, this message is intended to only be a warning and does not impact the functionality of the app, so I just added logic to ignore the warning and allow the user to continue using the application when it occurs.

#### Related Issue

Fixes #475 

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
