### PR TITLE
Always set LogicNode as root when created from sidebar

### DIFF
--- a/Emrald-UI/src/components/forms/LogicNodeForm/LogicNodeForm.tsx
+++ b/Emrald-UI/src/components/forms/LogicNodeForm/LogicNodeForm.tsx
@@ -22,6 +22,7 @@ interface LogicNodeFormProps {
   component?: string;
   editing?: boolean;
   setAsRoot?: boolean;
+  fromSidebar?: boolean;
 }
 
 const LogicNodeForm: React.FC<LogicNodeFormProps> = ({
@@ -31,6 +32,7 @@ const LogicNodeForm: React.FC<LogicNodeFormProps> = ({
   component,
   editing,
   parentNodeName,
+  fromSidebar,
 }) => {
   const {
     name,
@@ -62,7 +64,15 @@ const LogicNodeForm: React.FC<LogicNodeFormProps> = ({
   } = useLogicNodeFormContext();
 
   useEffect(() => {
-    initializeForm(logicNodeData, editing, component, parentNodeName, nodeType, gateType);
+    initializeForm(
+      logicNodeData,
+      editing,
+      component,
+      parentNodeName,
+      nodeType,
+      gateType,
+      fromSidebar ? true : undefined,
+    );
   }, []);
 
   return (
@@ -215,7 +225,7 @@ const LogicNodeForm: React.FC<LogicNodeFormProps> = ({
           >
             <FormControlLabel
               label="Make available as Top or Subtree"
-              disabled={availableAsTopOrSubtree()}
+              disabled={fromSidebar === true || availableAsTopOrSubtree()}
               control={
                 <Checkbox
                   checked={isRoot ? true : false}

--- a/Emrald-UI/src/components/forms/LogicNodeForm/LogicNodeFormContext.tsx
+++ b/Emrald-UI/src/components/forms/LogicNodeForm/LogicNodeFormContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { useWindowContext } from '../../../contexts/WindowContext';
 import { emptyLogicNode, useLogicNodeContext } from '../../../contexts/LogicNodeContext';
 import { useSignal } from '@preact/signals-react';
@@ -59,6 +59,7 @@ interface LogicNodeFormContextType {
     parentNodeName?: string,
     nodeType?: 'gate' | 'comp',
     gateType?: GateType,
+    isRoot?: boolean,
   ) => void;
 }
 
@@ -121,6 +122,7 @@ const LogicNodeFormContextProvider: React.FC<{ children: React.ReactNode }> = ({
     parentNodeName?: string,
     nodeType?: 'gate' | 'comp',
     gateType?: GateType,
+    isRoot?: boolean,
   ) => {
     setLogicNodeData(logicNodeInfo);
     setEditing(editing);
@@ -160,6 +162,9 @@ const LogicNodeFormContextProvider: React.FC<{ children: React.ReactNode }> = ({
     setCompDiagram(component ?? '');
     setDefaultValues(current?.stateValues && current.stateValues.length > 0 ? false : true);
     setGateTypeValue(gateType ?? ('gtAnd' as GateType));
+    if (typeof isRoot !== 'undefined') {
+      setIsRoot(isRoot);
+    }
   };
 
   const availableAsTopOrSubtree = () => {

--- a/Emrald-UI/src/components/layout/Accordion/Accordion.tsx
+++ b/Emrald-UI/src/components/layout/Accordion/Accordion.tsx
@@ -125,7 +125,7 @@ const MenuAccordion: React.FC<MenuAccordionProps> = ({
       addWindow(
         'New Logic Tree',
         <LogicNodeFormContextProvider>
-          <LogicNodeForm setAsRoot />
+          <LogicNodeForm setAsRoot fromSidebar={true} />
         </LogicNodeFormContextProvider>,
       );
     } else if (accordionPanel === 'External Sims') {


### PR DESCRIPTION
#### Description

When a new node is added from the sidebar, it will always have set as top checked and disabled.

#### Related Issue

Closes #504 

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
