### PR TITLE
Fixed timer not displaying saved value

### DIFF
--- a/Emrald-UI/src/components/forms/EventForm/FormFieldsByType/Timer.tsx
+++ b/Emrald-UI/src/components/forms/EventForm/FormFieldsByType/Timer.tsx
@@ -67,12 +67,6 @@ export const Timer: React.FC<EventFormProps> = ({ eventData }) => {
     setTime(convertToISOString(value));
   };
 
-  useEffect(() => {
-    if (!time) {
-      setTimerMilliseconds(0); // if time is a variable string, milliseconds will not be able to be converted to number
-    }
-  }, [useVariable]);
-
   return (
     <div>
       <FormControlLabel


### PR DESCRIPTION
#### Description

Fixes the timer value not displaying the saved value in timer events.

#### Related Issue

Fixes #565 

#### Changes Made

- Removed an old useeffect that was overwriting the timer milliseconds when the form loaded, causing the timer to display nothing instead of the value saved in the event

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
