### PR TITLE
Fix state rename leaking into the wrong diagram's states list

### DIFF
--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/EmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/EmraldDiagram.tsx
@@ -16,6 +16,7 @@ import { DownloadButton } from '@/components/diagrams/DownloadButton';
 import { StateNode } from '@/components/diagrams/EmraldDiagram/StateNodeComponent';
 import { ContextMenu } from '@/components/layout/ContextMenu/ContextMenu';
 import { emptyDiagram } from '@/contexts/DiagramContext';
+import { useWindowContext } from '@/contexts/WindowContext';
 import { CustomConnectionLine } from './Edges/ConnectionLineComponent';
 import { useContextMenu } from './useContextMenu';
 import { useEmraldDiagram } from './useEmraldDiagram';
@@ -25,12 +26,16 @@ interface EmraldDiagramProps {
   diagram: Diagram;
 }
 
+// The currently focused diagram. Driven by the active window (see the effect
+// below) rather than by render, so it stays correct when several diagrams are
+// open. Writing it on every render let a non-focused diagram's re-render
+// clobber it, which pointed edits at the wrong diagram.
 export const currentDiagram = signal(emptyDiagram);
 
 export const EmraldDiagram: React.FC<EmraldDiagramProps> = ({ diagram }) => {
   const [showMap, setShowMap] = useState(true);
   const [showBackgroundDots, setShowBackgroundDots] = useState(true);
-  currentDiagram.value = diagram;
+  const { activeWindowId, getWindowTitleById } = useWindowContext();
   const {
     nodes,
     edges,
@@ -59,11 +64,20 @@ export const EmraldDiagram: React.FC<EmraldDiagramProps> = ({ diagram }) => {
     onPaneContextMenu,
     onNodeContextMenu,
     onEdgeContextMenu,
-  } = useContextMenu(getStateNodes, setEdges);
+  } = useContextMenu(getStateNodes, setEdges, diagram);
 
   useEffect(() => {
     setTopDiagram(diagram);
   }, []);
+
+  // Only the diagram whose window is active is the "current" one. A diagram
+  // window's title is its name, so when this instance's window is focused we
+  // publish it to the shared signal. Non-focused diagrams leave it untouched.
+  useEffect(() => {
+    if (getWindowTitleById(activeWindowId) === diagram.name) {
+      currentDiagram.value = diagram;
+    }
+  }, [activeWindowId, diagram]);
   const nodeTypes = useMemo(() => ({ custom: StateNode }), []);
   const ref = useRef<HTMLDivElement>(null);
 

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
@@ -1,6 +1,6 @@
 import type { Edge, Node } from 'reactflow';
 import type { Option } from '@/components/layout/ContextMenu/ContextMenu';
-import type { Action, Event, State } from '@/types/EMRALD_Model';
+import type { Action, Diagram, Event, State } from '@/types/EMRALD_Model';
 import type { ModelItem } from '@/types/ModelUtils';
 import { type MouseEvent, useState } from 'react';
 import { ActionForm } from '@/components/forms/ActionForm/ActionForm';
@@ -16,11 +16,11 @@ import { useStateContext } from '@/contexts/StateContext';
 import { useWindowContext } from '@/contexts/WindowContext';
 import { updateAppData } from '@/hooks/useAppData';
 import { updateModelAndReferences } from '@/utils/UpdateModel';
-import { currentDiagram } from './EmraldDiagram';
 
 export function useContextMenu(
   getStateNodes?: () => void,
   setEdges?: (edges: Edge[]) => void,
+  diagram?: Diagram,
 ) {
   // Get state nodes function is needed if deleting or removing a state, set edges function is needed if deleting or removing an edge
   const [menu, setMenu] = useState<{ mouseX: number; mouseY: number } | null>(
@@ -33,7 +33,7 @@ export function useContextMenu(
   const [actionTypeToModify, setActionTypeToModify] = useState<string>();
   const { addWindow } = useWindowContext();
   const { updateState, deleteState, getStateByStateId } = useStateContext();
-  const { updateDiagram } = useDiagramContext();
+  const { updateDiagram, getDiagramByDiagramName } = useDiagramContext();
   const { deleteEvent } = useEventContext();
   const { updateAction, deleteAction, getActionByActionId }
     = useActionContext();
@@ -57,7 +57,7 @@ export function useContextMenu(
       {
         label: 'New State',
         action: () => {
-          addWindow('New State', <StateForm />);
+          addWindow('New State', <StateForm diagram={diagram} />);
           closeContextMenu();
         },
         isDivider: true,
@@ -65,10 +65,12 @@ export function useContextMenu(
       {
         label: 'Diagram Properties',
         action: () => {
-          addWindow(
-            `Edit Properties ${currentDiagram.value.name}`,
-            <DiagramForm diagramData={currentDiagram.value} />,
-          );
+          if (diagram) {
+            addWindow(
+              `Edit Properties ${diagram.name}`,
+              <DiagramForm diagramData={diagram} />,
+            );
+          }
           closeContextMenu();
         },
       },
@@ -644,10 +646,18 @@ export function useContextMenu(
     }
 
     if (itemToDelete.id && itemToDelete.objType === 'State' && getStateNodes) {
-      currentDiagram.value.states = currentDiagram.value.states.filter(
-        state => state !== itemToDelete.name,
-      );
-      updateDiagram(currentDiagram.value);
+      // Remove the state from the diagram that actually owns it (tracked on the
+      // state itself) rather than the shared currentDiagram signal, which may
+      // point at a different open diagram.
+      const owningDiagram = getDiagramByDiagramName(itemToDelete.diagramName);
+      if (owningDiagram) {
+        updateDiagram({
+          ...owningDiagram,
+          states: owningDiagram.states.filter(
+            state => state !== itemToDelete.name,
+          ),
+        });
+      }
       deleteState(itemToDelete.id);
       getStateNodes();
     } else if (

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
@@ -24,7 +24,7 @@ import { ActionFormContextProvider } from '../../forms/ActionForm/ActionFormCont
 import { StateForm } from '../../forms/StateForm/StateForm';
 import { getEventActionEdges } from './Edges/EventActionEdge';
 import { getImmediateActionEdges } from './Edges/ImmediateActionEdge';
-import { currentDiagram, EmraldDiagram } from './EmraldDiagram';
+import { EmraldDiagram } from './EmraldDiagram';
 
 export function useEmraldDiagram() {
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
@@ -253,11 +253,12 @@ export function useEmraldDiagram() {
   const getActionNewStates = (action?: Action) =>
     action?.newStates?.map((state: { toState: string }) => state.toState) ?? [];
 
-  // Check if the new states are in the current diagram
+  // Check if the new states are in this diagram (the one this hook instance
+  // is bound to), not whichever diagram last rendered into the shared signal.
   const isStateInCurrentDiagram = (action?: Action) =>
     action
       ? getActionNewStates(action).every(newState =>
-          currentDiagram.value.states.includes(newState),
+          topDiagram.states.includes(newState),
         )
       : false;
 

--- a/Emrald-UI/src/components/forms/StateForm/StateForm.tsx
+++ b/Emrald-UI/src/components/forms/StateForm/StateForm.tsx
@@ -1,4 +1,5 @@
 import type {
+  Diagram,
   DiagramType,
   State,
   StateEvalValue,
@@ -19,19 +20,20 @@ import { v4 as uuidv4 } from 'uuid';
 import { useDiagramContext } from '../../../contexts/DiagramContext';
 import { emptyState, useStateContext } from '../../../contexts/StateContext';
 import { useWindowContext } from '../../../contexts/WindowContext';
-import { currentDiagram } from '../../diagrams/EmraldDiagram/EmraldDiagram';
 import { MainDetailsForm } from '../../forms/MainDetailsForm';
 
 interface StateFormProps {
   stateData?: State;
+  diagram?: Diagram;
 }
 
 export const StateForm: React.FC<StateFormProps> = ({
   stateData,
+  diagram,
 }: StateFormProps) => {
   const { handleClose } = useWindowContext();
   const { statesList, updateState, createState } = useStateContext();
-  const { updateDiagram } = useDiagramContext();
+  const { updateDiagram, getDiagramByDiagramName } = useDiagramContext();
   const state = useSignal(stateData ?? emptyState);
   const [name, setName] = useState(stateData?.name ?? '');
   const [desc, setDesc] = useState(stateData?.desc ?? '');
@@ -43,6 +45,13 @@ export const StateForm: React.FC<StateFormProps> = ({
     = useState<StateEvalValue>(stateData?.defaultSingleStateValue ?? 'Ignore');
   const [hasError, setHasError] = useState(false);
   const [originalName] = useState(stateData?.name ?? '');
+
+  // The diagram a state belongs to is authoritative on the state itself
+  // (a state can only be in one diagram). For new states there is no
+  // diagramName yet, so use the diagram the form was opened from. We never
+  // rely on the shared `currentDiagram` signal here, which points at whichever
+  // diagram rendered last and is wrong when multiple diagrams are open.
+  const owningDiagramName = stateData?.diagramName ?? diagram?.name ?? '';
 
   const stateTypeOptions = [
     { value: 'stStart', label: 'Start' },
@@ -63,46 +72,46 @@ export const StateForm: React.FC<StateFormProps> = ({
   };
 
   const handleSave = () => {
+    const trimmedName = name.trim();
     if (stateData) {
+      // updateState renames the state and updates every reference to it,
+      // including the owning diagram's `states` list (see
+      // updateModelAndReferences in UpdateModel.ts). No manual diagram update
+      // is needed here, and doing one against the global currentDiagram could
+      // add the name to the wrong diagram when several are open.
       updateState({
         ...state.value,
         stateType,
-        name: name.trim(),
+        name: trimmedName,
         desc,
         defaultSingleStateValue,
       });
-      if (name !== originalName) {
-        currentDiagram.value.states = [
-          ...currentDiagram.value.states.filter(
-            state => state !== originalName,
-          ),
-          name,
-        ];
-        updateDiagram({
-          ...currentDiagram.value,
-        });
-      }
     } else {
       createState({
         ...state.value,
         id: uuidv4(),
-        name: name.trim(),
+        name: trimmedName,
         desc,
         stateType,
         defaultSingleStateValue,
-        diagramName: currentDiagram.value.name || '',
+        diagramName: owningDiagramName,
       });
-      const { states } = currentDiagram.value;
-      currentDiagram.value.states = [...states, name.trim()];
-      updateDiagram({
-        ...currentDiagram.value,
-      });
+      const owningDiagram = getDiagramByDiagramName(owningDiagramName);
+      if (owningDiagram) {
+        updateDiagram({
+          ...owningDiagram,
+          states: [...owningDiagram.states, trimmedName],
+        });
+      }
     }
     handleClose();
   };
 
   useEffect(() => {
-    setDiagramType(currentDiagram.value.diagramType);
+    const owningDiagram = getDiagramByDiagramName(owningDiagramName);
+    if (owningDiagram) {
+      setDiagramType(owningDiagram.diagramType);
+    }
   }, []);
   return (
     <Box mx={3} pb={3}>


### PR DESCRIPTION
#### Description

When two or more diagrams are open, renaming a state in one diagram could add the new name to a *different* (non-focused) diagram's `states` list. After a refresh, the unrelated diagram showed the renamed state and its JSON `states` array contained the new name.

The root cause was that `StateForm.handleSave` manually appended the new name to `currentDiagram.value.states` on rename, while the global `currentDiagram` signal was overwritten on **every** `EmraldDiagram` render rather than on focus. A re-render of the non-focused diagram (e.g. from an unrelated edit in it) left the signal pointing at the wrong diagram, so the append landed there. The actual rename is already handled by `updateModelAndReferences` (it rewrites `DiagramList[*].states` via jsonpath), so the manual append was both redundant and the source of the bug.

#### Related Issue

Fixes #589

#### Changes Made

- **StateForm**: removed the redundant manual `states` update on rename (`updateModelAndReferences` already rewrites `DiagramList[*].states`); resolve the owning diagram from authoritative sources — `State.diagramName` for edits, the originating diagram for new states — instead of the shared `currentDiagram` signal.
- **useContextMenu**: scoped "New State", "Diagram Properties", and state deletion to the diagram passed from the `EmraldDiagram` instance / the state's own `diagramName`, instead of the global signal.
- **EmraldDiagram**: the `currentDiagram` signal is now driven by the active window (`activeWindowId`) rather than by render, so it reliably reflects the focused diagram even when several are open.
- **useEmraldDiagram**: uses the per-instance `topDiagram` instead of `currentDiagram` for the "is this state in this diagram" check.

#### Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation (N/A — no UI layout changes)
- [x] My changes generate no new warnings (ESLint passes with `--max-warnings=0`)
- [ ] I have added tests that prove my fix is effective or that my feature works (see Additional Notes)
- [x] New and existing unit tests pass locally with my changes (StateForm suite verified)

#### Screenshots (if applicable)

N/A — no visual changes.

#### Additional Notes

- No new automated test was added for the multi-diagram rename scenario; it depends on window-focus (`activeWindowId`) state that the current `StateForm` test harness does not set up. Suggest a manual check with two diagrams open: rename/create/delete states and confirm each lands in the correct diagram, and that the sidebar's local lists still follow focus.
- The `currentDiagram` signal is now effectively reliable for any consumer that needs the focused diagram; the existing sidebar focus logic (`activeWindowId` effect) was left unchanged and now computes the same value.
