### PR TITLE
Fix invalid JSON timespan for timer events with no duration (#572)

### DIFF
--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/Edges/EventActionEdge.ts
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/Edges/EventActionEdge.ts
@@ -68,6 +68,14 @@ export function getEventActionEdges(
   ) => { toState: string; prob: number }[],
 ) {
   for (const [index, action] of eventActions.entries()) {
+    // events and eventActions are 1-to-1 parallel arrays. Older models can
+    // carry orphaned eventActions entries (an event was deleted without
+    // removing its matching eventActions slot). Skip any entry that has no
+    // corresponding event so the edges match what the node actually renders,
+    // which loops over events.
+    if (index >= events.length) {
+      continue;
+    }
     if (action.actions) {
       for (const actionName of action.actions) {
         const newStates = getNewStatesByActionName(actionName);

--- a/Emrald-UI/src/components/forms/EventForm/FormFieldsByType/Timer.tsx
+++ b/Emrald-UI/src/components/forms/EventForm/FormFieldsByType/Timer.tsx
@@ -26,6 +26,10 @@ export const Timer: React.FC<EventFormProps> = ({ eventData }) => {
     if (eventData?.time !== undefined) {
       setTime(eventData.time);
       setTimerMilliseconds(moment.duration(eventData.time).asMilliseconds());
+    } else if (!eventData?.useVariable) {
+      // Default to a valid zero-duration timespan so an untouched timer
+      // produces valid JSON (triggers immediately) instead of an empty value.
+      setTime(convertToISOString(0));
     }
     setUseVariable(eventData?.useVariable);
     setOnVarChange(eventData?.onVarChange);

--- a/SimulationDAL/Events.cs
+++ b/SimulationDAL/Events.cs
@@ -1086,7 +1086,11 @@ namespace SimulationDAL
       }   
       else
       {
-        this.time = XmlConvert.ToTimeSpan((string)dynObj.time);
+        string timeStr = (string)dynObj.time;
+        if (string.IsNullOrWhiteSpace(timeStr))
+          this.time = TimeSpan.FromTicks(0); //no duration entered, trigger immediately
+        else
+          this.time = XmlConvert.ToTimeSpan(timeStr);
       }
 
       if (dynObj.fromSimStart != null)


### PR DESCRIPTION
#### Description

When a Timer event was created without entering a duration, the application produced an invalid/empty timespan instead of a valid JSON time value. The duration form left `time` undefined (so it was stripped on save), and the simulation engine then threw when parsing the null/empty string via `XmlConvert.ToTimeSpan`, breaking model load. This PR makes an untouched timer default to a valid zero-duration timespan (trigger immediately) and hardens the engine against missing/empty timer times.

Also fixed possible simple display issue with bad data.

#### Related Issue

Fixes #572

#### Changes Made

- **`Emrald-UI/.../EventForm/FormFieldsByType/Timer.tsx`**: When a duration-mode timer has no time entered, default `time` to a valid zero-duration timespan (`P0D`) so it serializes to valid JSON and triggers immediately. The variable-mode path is left untouched.
- **`SimulationDAL/Events.cs`**: Guard `TimerEvent.DeserializeDerived` against a null/empty/whitespace `time` string, defaulting to `TimeSpan` zero, so older or hand-edited models containing an empty timer time load safely instead of throwing.
- **`Emrald-UI/.../EmraldDiagram/Edges/EventActionEdge.ts`**: Skip orphaned `eventActions` entries (an event deleted without removing its matching `eventActions` slot) when building diagram edges, so edges align with the events the node actually renders.

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)

N/A

#### Additional Notes

- Existing Timer UI tests pass (3/3). The 20 unrelated test failures present in the suite (Action/MAAP forms, etc.) were confirmed pre-existing on a clean `v3_Devel` checkout and are not introduced by this change.
- A regression test for the empty-duration save case was not added in this PR; happy to add one if desired.
