### PR TITLE
Fix RunExtApp ignoring exePath when args contain ".exe"

### DIFF
--- a/SimulationDAL/Actions.cs
+++ b/SimulationDAL/Actions.cs
@@ -1658,8 +1658,11 @@ namespace SimulationDAL
       string runParams = makeInputFileCompEval.EvaluateString();
       var locExePath = exePath;
 
+      // Only infer the exe from runParams when no exePath was explicitly configured.
+      // Otherwise an argument value that merely contains ".exe" (e.g. "--model C:\...\foo.exe")
+      // would be mistaken for the executable and clobber the real exePath.
       // Check if runParams contains an exe path (look for .exe extension)
-      if (!string.IsNullOrEmpty(runParams))
+      if (string.IsNullOrEmpty(locExePath) && !string.IsNullOrEmpty(runParams))
       {
         int exeIdx = runParams.IndexOf(".exe", StringComparison.OrdinalIgnoreCase);
         if (exeIdx > 0)


### PR DESCRIPTION
@
#### Description

A "Run Application" (`atRunExtApp`) action was failing with `No executable specified for RunExtApp - <ActionName>` whenever the generated command-line arguments contained the text `.exe`. The engine has a heuristic that infers the executable from the argument string, but it ran unconditionally and overrode a perfectly valid configured `exePath`. This PR gates that inference so it only runs when no `exePath` was provided.

#### Related Issue

Fixes #592

#### Changes Made

- `SimulationDAL/Actions.cs`: only infer the executable from `runParams` when `exePath` is empty (`string.IsNullOrEmpty(locExePath)`), restoring the pre-#527 behavior.
- Added an explanatory comment describing why the inference must be gated.

#### Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Additional Notes

This regressed in commit bc3af7d7 (#527), which dropped the original `if (locExePath == "")` guard around the exe-inference logic. The fix restores that intent while keeping the newer `.exe`-based extraction for the empty-`exePath` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@