### PR TITLE
Add workflow: comment "next release" on merged PRs' linked issues

### DIFF
--- a/.github/workflows/notify-linked-issues-on-merge.yml
+++ b/.github/workflows/notify-linked-issues-on-merge.yml
@@ -1,0 +1,58 @@
+name: Notify linked issues on merge
+
+# When a PR that closes one or more issues is merged, GitHub already closes
+# those issues automatically (via "Fixes/Closes/Resolves #N" keywords or the
+# PR's "Development" links). This workflow adds a comment to each of those
+# issues noting that the fix will ship in the next release.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  comment-next-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on closing-referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const number = context.payload.pull_request.number;
+
+            // closingIssuesReferences captures both keyword-based closes
+            // (Fixes/Closes/Resolves #N) and issues manually linked via the
+            // PR's "Development" sidebar.
+            const result = await github.graphql(`
+              query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    closingIssuesReferences(first: 50) {
+                      nodes { number }
+                    }
+                  }
+                }
+              }`, { owner, repo, number });
+
+            const issues = result.repository.pullRequest
+              .closingIssuesReferences.nodes;
+
+            if (issues.length === 0) {
+              core.info('No closing issue references found; nothing to comment.');
+              return;
+            }
+
+            for (const issue of issues) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body: `Resolved by #${number}. This fix will be included in the next release.`,
+              });
+              core.info(`Commented on issue #${issue.number}`);
+            }


### PR DESCRIPTION
@
#### Description

Adds a GitHub Actions workflow so that when a PR tied to one or more issues is merged, each linked issue automatically gets a comment noting the fix will ship in the next release. GitHub already auto-closes those issues on merge (via `Fixes/Closes/Resolves #N` keywords or the PR "Development" links); this workflow adds the release note on top of that.

#### Related Issue

N/A (process/automation improvement)

#### Changes Made

- Added `.github/workflows/notify-linked-issues-on-merge.yml`, triggered on `pull_request: closed` and gated on `merged == true`.
- Uses the GraphQL `closingIssuesReferences` field to find every issue the PR closes (keyword-based or manually linked), then posts a comment on each.

#### Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Additional Notes

- The workflow only takes effect for PRs merged **after** it lands on the default branch (`v3_Devel`), since `pull_request` workflows run from the base branch.
- Requires repository Actions setting **Workflow permissions → Read and write** (Settings → Actions → General) so the `GITHUB_TOKEN` can comment on issues. The workflow declares `permissions: issues: write`, but an org/repo default of read-only will still block it.
- The comment wording (`This fix will be included in the next release.`) is a one-line edit if you want different phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@