### PR TITLE
Fix ExtSim on variable not loading or assigning correctly (#583)

### DIFF
--- a/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/ExtSimFields.tsx
+++ b/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/ExtSimFields.tsx
@@ -35,7 +35,7 @@ export const ExtSimFields: React.FC<VariableFormProps> = ({ variableData }) => {
         value={extSim}
       >
         {extSims.map(e => (
-          <MenuItem key={e.id} value={e.id}>
+          <MenuItem key={e.id} value={e.name}>
             {e.name}
           </MenuItem>
         ))}

--- a/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.expected.json
+++ b/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.expected.json
@@ -55,6 +55,20 @@
     "cumulativeStats": false,
     "monitorInSim": false
   },
+  "ext_sim_link_variable": {
+    "objType": "Variable",
+    "name": "ext_sim_link_variable",
+    "desc": "",
+    "resetOnRuns": true,
+    "type": "string",
+    "value": "Test",
+    "varScope": "gt3DSim",
+    "sim3DId": "1234",
+    "extSim": "MooseSim",
+    "canMonitor": false,
+    "cumulativeStats": false,
+    "monitorInSim": false
+  },
   "doc_link_variable": {
     "objType": "Variable",
     "name": "doc_link_variable",

--- a/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
@@ -2,7 +2,14 @@ import { findByRole, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, test } from 'vitest';
 import { VariableForm } from '@/components/forms/VariableForm/VariableForm';
-import { drag, ensureState, getVariable, renderVariableForm, save } from '@/tests/test-utils';
+import {
+  drag,
+  ensureExtSim,
+  ensureState,
+  getVariable,
+  renderVariableForm,
+  save,
+} from '@/tests/test-utils';
 import expected from './VariableForm.expected.json';
 
 describe('Variable Form', () => {
@@ -93,6 +100,62 @@ describe('Variable Form', () => {
 
     await save();
     expect(getVariable(name)).toEqual(expected[name]);
+  });
+
+  // Issue #583: selecting an external sim must store its name, not its UUID.
+  test('ext sim variable links to external sim by name', async () => {
+    const name = 'ext_sim_link_variable';
+    ensureExtSim('MooseSim');
+    renderVariableForm(
+      <VariableForm
+        variableData={{
+          objType: 'Variable',
+          name,
+          desc: '',
+          varScope: 'gt3DSim',
+          value: '',
+          type: 'string',
+        }}
+      />,
+    );
+    const user = userEvent.setup();
+
+    // Enter values
+    await user.type(await screen.findByLabelText('Value'), 'Test');
+    await user.type(await screen.findByLabelText('3DSimID'), '1234');
+
+    // Select the external sim from the dropdown
+    await user.click(await findByRole(await screen.findByLabelText('External Sim'), 'combobox'));
+    await user.click(await screen.findByRole('option', { name: 'MooseSim' }));
+
+    await save();
+    const variable = getVariable(name);
+    // The stored value must be the sim's name, not its UUID.
+    expect(variable?.extSim).toBe('MooseSim');
+    expect(variable).toEqual(expected[name]);
+  });
+
+  // Issue #583: an existing variable whose extSim is a name must display that name.
+  test('ext sim variable displays linked external sim by name', async () => {
+    ensureExtSim('MooseSim');
+    renderVariableForm(
+      <VariableForm
+        variableData={{
+          objType: 'Variable',
+          name: 'ext_sim_display_variable',
+          desc: '',
+          varScope: 'gt3DSim',
+          value: 5.3125,
+          type: 'double',
+          sim3DId: 'Postprocessors/tritium_burn_rate/value',
+          extSim: 'MooseSim',
+        }}
+      />,
+    );
+
+    // The External Sim field should show the linked sim's name.
+    const combobox = await findByRole(await screen.findByLabelText('External Sim'), 'combobox');
+    expect(combobox).toHaveTextContent('MooseSim');
   });
 
   test('doc link variable', async () => {


### PR DESCRIPTION
Fixes #583

## Problem
In the Variable form, the **External Sim** dropdown used each ExtSim's `id` as the `MenuItem` value instead of its `name`. The `Variable.extSim` field is defined by the v3.2 schema as the *name* of the linked external simulation, which produced both reported symptoms:

1. **Not displaying** — a variable whose `extSim` is a name (e.g. `"MooseSim"`) showed nothing in the field, because the dropdown's MenuItem values were UUIDs and none matched.
2. **Wrong value on assign** — selecting an entry stored the ExtSim's UUID (e.g. `"02aa22af-..."`) instead of its name.

## Fix
[`ExtSimFields.tsx`](Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/ExtSimFields.tsx): change the `MenuItem` value from `e.id` to `e.name`, matching the equivalent dropdown already used correctly in the Action form ([`ExtSimulation.tsx`](Emrald-UI/src/components/forms/ActionForm/FormFieldsByType/ExtSimulation.tsx)).

```diff
-          <MenuItem key={e.id} value={e.id}>
+          <MenuItem key={e.id} value={e.name}>
```

## Tests
Added two `VariableForm` tests:
- **links to external sim by name** — selects an ExtSim from the dropdown and asserts the saved `extSim` is the name, not a UUID.
- **displays linked external sim by name** — renders a variable whose `extSim` is a name and asserts the field shows it.

Both tests were confirmed to **fail without the fix** and pass with it. Full `VariableForm` suite (6 tests) passes; lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)