### PR TITLE
Disallow non-exiting transition actions in single-state diagrams (#563)

### DIFF
--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
@@ -10,12 +10,14 @@ import { EventForm } from '@/components/forms/EventForm/EventForm';
 import { EventFormContextProvider } from '@/components/forms/EventForm/EventFormContext';
 import { StateForm } from '@/components/forms/StateForm/StateForm';
 import { useActionContext } from '@/contexts/ActionContext';
+import { useAlertContext } from '@/contexts/AlertContext';
 import { useDiagramContext } from '@/contexts/DiagramContext';
 import { useEventContext } from '@/contexts/EventContext';
 import { useStateContext } from '@/contexts/StateContext';
 import { useWindowContext } from '@/contexts/WindowContext';
 import { updateAppData } from '@/hooks/useAppData';
 import { updateModelAndReferences } from '@/utils/UpdateModel';
+import { SINGLE_STATE_EXIT_FLAG_MESSAGE } from '@/utils/util-functions';
 
 export function useContextMenu(
   getStateNodes?: () => void,
@@ -37,6 +39,12 @@ export function useContextMenu(
   const { deleteEvent } = useEventContext();
   const { updateAction, deleteAction, getActionByActionId }
     = useActionContext();
+  const { showAlert } = useAlertContext();
+
+  // A single-state diagram (dtSingle) can only be in one state at a time, so a
+  // transition action must always exit the current state.
+  const isSingleStateDiagram = (state: State) =>
+    getDiagramByDiagramName(state.diagramName)?.diagramType === 'dtSingle';
 
   const closeContextMenu = () => {
     setMenu(null);
@@ -210,7 +218,15 @@ export function useContextMenu(
           ) as ModelItem;
           if (pastedData.objType === 'Action') {
             const actionName = pastedData.name;
-            if (state.immediateActions.includes(actionName)) {
+            if (
+              pastedData.actType === 'atTransition'
+              && isSingleStateDiagram(state)
+            ) {
+              showAlert(
+                'Transition actions are not allowed in the immediate actions of a single state diagram.',
+                'warning',
+              );
+            } else if (state.immediateActions.includes(actionName)) {
               console.warn('Action already exists');
             } else {
               state.immediateActions.push(actionName);
@@ -322,10 +338,21 @@ export function useContextMenu(
           ) as ModelItem;
           if (pastedData.objType === 'Action') {
             const eventIndex = state.events.indexOf(event.name);
-            const eventActions = state.eventActions[eventIndex]?.actions;
+            const eventAction = state.eventActions[eventIndex];
 
-            if (!eventActions?.includes(pastedData.name)) {
-              eventActions?.push(pastedData.name);
+            if (!eventAction?.actions.includes(pastedData.name)) {
+              eventAction?.actions.push(pastedData.name);
+              // In a single-state diagram a transition must exit the state, so
+              // set the event's "exit state" flag if it isn't already set.
+              if (
+                eventAction
+                && pastedData.actType === 'atTransition'
+                && !eventAction.moveFromCurrent
+                && isSingleStateDiagram(state)
+              ) {
+                eventAction.moveFromCurrent = true;
+                showAlert(SINGLE_STATE_EXIT_FLAG_MESSAGE, 'info');
+              }
               updateState(state);
               updateAppData(updateModelAndReferences(state, 'State'));
             }

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
@@ -253,12 +253,19 @@ export function useEmraldDiagram() {
   const getActionNewStates = (action?: Action) =>
     action?.newStates?.map((state: { toState: string }) => state.toState) ?? [];
 
+  // topDiagram is a snapshot taken when the window opened, so its `states`
+  // array goes stale as states are added/removed. Resolve the current list
+  // from the live model by this window's diagram name (names are unique, so
+  // multiple open diagrams stay independent).
+  const getCurrentDiagramStates = () =>
+    getDiagramByDiagramName(topDiagram.name)?.states ?? topDiagram.states;
+
   // Check if the new states are in this diagram (the one this hook instance
   // is bound to), not whichever diagram last rendered into the shared signal.
   const isStateInCurrentDiagram = (action?: Action) =>
     action
       ? getActionNewStates(action).every(newState =>
-          topDiagram.states.includes(newState),
+          getCurrentDiagramStates().includes(newState),
         )
       : false;
 
@@ -283,7 +290,7 @@ export function useEmraldDiagram() {
 
   // Build the state nodes
   const getStateNodes = () => {
-    const stateNodes = topDiagram.states.map(state => {
+    const stateNodes = getCurrentDiagramStates().map(state => {
       const stateDetails = getStateByStateName(state);
       const { x, y } = {
         x: stateDetails?.geometryInfo?.x ?? 0,

--- a/Emrald-UI/src/components/forms/ActionForm/ActionForm.tsx
+++ b/Emrald-UI/src/components/forms/ActionForm/ActionForm.tsx
@@ -7,6 +7,7 @@ import type {
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { createElement, useEffect } from 'react';
+import { useDiagramContext } from '../../../contexts/DiagramContext';
 import { MainDetailsForm } from '../MainDetailsForm';
 import { useActionFormContext } from './ActionFormContext';
 import {
@@ -51,10 +52,30 @@ export const ActionForm: React.FC<ActionFormProps> = ({
     initializeForm,
     reset,
   } = useActionFormContext();
+  const { getDiagramByDiagramName } = useDiagramContext();
+
+  // Transition actions are not allowed as immediate actions in a single-state
+  // diagram. This only applies when creating a brand-new action under the
+  // Immediate Actions section (state, no event). Editing an existing action
+  // (only actionData) is unaffected.
+  const disallowTransition
+    = !!state
+      && !event
+      && getDiagramByDiagramName(state.diagramName)?.diagramType === 'dtSingle';
 
   useEffect(() => {
     initializeForm(actionData);
+    // The form defaults to the (now-disabled) Transition type, so move it off
+    // of that for a new immediate action in a single-state diagram.
+    if (disallowTransition && !actionData) {
+      setActType('atCngVarVal');
+    }
   }, []);
+
+  const typeOptions = actionTypeOptions.map(option => ({
+    ...option,
+    disabled: disallowTransition && option.value === 'atTransition',
+  }));
 
   // Map action types to their respective sub-components and props
   const actionTypeToComponent: Record<
@@ -77,7 +98,7 @@ export const ActionForm: React.FC<ActionFormProps> = ({
           itemType="Action"
           type={actType}
           setType={setActType}
-          typeOptions={actionTypeOptions}
+          typeOptions={typeOptions}
           name={name}
           handleNameChange={handleNameChange}
           desc={desc}

--- a/Emrald-UI/src/components/forms/DiagramForm/DiagramForm.tsx
+++ b/Emrald-UI/src/components/forms/DiagramForm/DiagramForm.tsx
@@ -32,6 +32,7 @@ import { appData } from '../../../hooks/useAppData';
 import { upgradeModel } from '../../../utils/Upgrades/upgrade';
 import { FileUploadComponent, TabPanel } from '../../common';
 import { GroupListItems } from '../../common/GroupListItems';
+import { EmraldDiagram } from '../../diagrams/EmraldDiagram/EmraldDiagram';
 import { MainDetailsForm } from '../../forms/MainDetailsForm';
 import { ImportForm } from '../ImportForm/ImportForm';
 
@@ -58,9 +59,19 @@ export const DiagramForm: React.FC<DiagramFormProps> = ({ diagramData }) => {
     { value: 'dtSingle', label: 'Single State (Evaluation)' },
     { value: 'dtMulti', label: 'Multi State' },
   ];
+  // New diagrams default to Multi State, whose default group label is "Plant".
+  // Single State defaults to "Component". The default follows the type until
+  // the user sets the label manually (tracked by labelEdited).
   const [diagramLabel, setDiagramLabel] = useState(
-    diagramData?.diagramLabel ?? '',
+    diagramData?.diagramLabel ?? 'Plant',
   );
+  const [labelEdited, setLabelEdited] = useState(false);
+
+  const handleDiagramTypeChange = (newType: DiagramType) => {
+    if (!diagramData && !labelEdited) {
+      setDiagramLabel(newType === 'dtSingle' ? 'Component' : 'Plant');
+    }
+  };
   const diagrams = appData.value.DiagramList;
   const diagramLabelsSet = new Set(diagrams.map(d => d.diagramLabel));
   const diagramLabels = Array.from(diagramLabelsSet);
@@ -112,17 +123,26 @@ export const DiagramForm: React.FC<DiagramFormProps> = ({ diagramData }) => {
           diagramType,
           diagramLabel,
         });
+        handleClose();
       } else {
-        createDiagram({
+        const newDiagram = {
           ...diagram.value,
           id: uuidv4(),
           name: name.trim(),
           desc,
           diagramType,
           diagramLabel: diagramLabel || 'Component',
-        });
+        };
+        createDiagram(newDiagram);
+        // Open the newly created diagram, replacing this form window.
+        addWindow(
+          newDiagram.name,
+          <EmraldDiagram diagram={newDiagram} />,
+          { x: 75, y: 25, width: 1000, height: 500 },
+          null,
+          formWindowId ?? undefined,
+        );
       }
-      handleClose();
     }
   };
 
@@ -222,6 +242,7 @@ export const DiagramForm: React.FC<DiagramFormProps> = ({ diagramData }) => {
             itemType="Diagram"
             type={diagramType}
             setType={setDiagramType}
+            handleTypeChange={handleDiagramTypeChange}
             typeOptions={diagramTypeOptions}
             typeDisabled={
               !!selectedTemplate || !!importDiagram || !!diagramData
@@ -251,9 +272,15 @@ export const DiagramForm: React.FC<DiagramFormProps> = ({ diagramData }) => {
               )}
               onChange={(_event, newValue) => {
                 setDiagramLabel(newValue ?? '');
+                setLabelEdited(true);
               }}
-              onInputChange={(_event, newInputValue) => {
+              onInputChange={(_event, newInputValue, reason) => {
                 setDiagramLabel(newInputValue);
+                // Ignore MUI's programmatic 'reset' (fired when we set the
+                // label from a type change); only user input/clear counts.
+                if (reason === 'input' || reason === 'clear') {
+                  setLabelEdited(true);
+                }
               }}
               value={diagramLabel}
               fullWidth

--- a/Emrald-UI/src/components/forms/MainDetailsForm.tsx
+++ b/Emrald-UI/src/components/forms/MainDetailsForm.tsx
@@ -34,7 +34,7 @@ interface MainDetailsFormProps<T extends MainItemType> {
   itemType: T;
   typeLabel?: string;
   type: ValueTypes<T>;
-  typeOptions: { value: string; label: string }[];
+  typeOptions: { value: string; label: string; disabled?: boolean }[];
   typeDisabled?: boolean;
   nameDisabled?: boolean;
   descDisabled?: boolean;
@@ -98,7 +98,11 @@ export function MainDetailsForm<T extends MainItemType>({
           label={typeLabel ?? 'Type'}
         >
           {typeOptions.map(option => (
-            <MenuItem key={option.value} value={option.value}>
+            <MenuItem
+              key={option.value}
+              value={option.value}
+              disabled={option.disabled}
+            >
               {option.label}
             </MenuItem>
           ))}

--- a/Emrald-UI/src/contexts/ActionContext.tsx
+++ b/Emrald-UI/src/contexts/ActionContext.tsx
@@ -17,6 +17,7 @@ import {
   formatClearedRefsMessage,
   updateModelAndReferences,
 } from '../utils/UpdateModel';
+import { SINGLE_STATE_EXIT_FLAG_MESSAGE } from '../utils/util-functions';
 import { useAlertContext } from './AlertContext';
 
 interface ActionContextType {
@@ -88,9 +89,20 @@ export const ActionContextProvider: React.FC<PropsWithChildren> = ({
   const createAction = (newAction: Action, event?: Event, state?: State) => {
     updateAppData(updateModelAndReferences(newAction, 'Action'));
     if (event && state) {
-      state.eventActions[state.events.indexOf(event.name)]?.actions.push(
-        newAction.name,
-      );
+      const eventAction = state.eventActions[state.events.indexOf(event.name)];
+      eventAction?.actions.push(newAction.name);
+      // In a single-state diagram a transition must exit the state, so set the
+      // event's "exit state" flag if it isn't already set.
+      if (
+        eventAction
+        && newAction.actType === 'atTransition'
+        && !eventAction.moveFromCurrent
+        && appData.value.DiagramList.find(d => d.name === state.diagramName)
+          ?.diagramType === 'dtSingle'
+      ) {
+        eventAction.moveFromCurrent = true;
+        showAlert(SINGLE_STATE_EXIT_FLAG_MESSAGE, 'info');
+      }
       updateAppData(updateModelAndReferences(state, 'State'));
     } else if (state) {
       state.immediateActions.push(newAction.name);

--- a/Emrald-UI/src/contexts/StateContext.tsx
+++ b/Emrald-UI/src/contexts/StateContext.tsx
@@ -17,6 +17,7 @@ import {
   formatClearedRefsMessage,
   updateModelAndReferences,
 } from '../utils/UpdateModel';
+import { SINGLE_STATE_EXIT_FLAG_MESSAGE } from '../utils/util-functions';
 import { useAlertContext } from './AlertContext';
 
 interface StateContextType {
@@ -137,6 +138,13 @@ export const StateContextProvider: React.FC<PropsWithChildren> = ({
     }
   };
 
+  // A single-state diagram (dtSingle) can only be in one state at a time, so a
+  // transition action must always exit the current state. Look the diagram up
+  // by the state's owning diagram name.
+  const isSingleStateDiagram = (state: State) =>
+    appData.value.DiagramList.find(d => d.name === state.diagramName)
+      ?.diagramType === 'dtSingle';
+
   const updateStateEventActions = (
     stateName: string,
     eventName: string,
@@ -152,6 +160,16 @@ export const StateContextProvider: React.FC<PropsWithChildren> = ({
           return;
         }
         stateToUpdate.eventActions[eventIndex].actions.push(action.name);
+        // In a single-state diagram a transition must exit the state, so set
+        // the event's "exit state" flag if it isn't already set.
+        if (
+          action.actType === 'atTransition'
+          && isSingleStateDiagram(stateToUpdate)
+          && !stateToUpdate.eventActions[eventIndex].moveFromCurrent
+        ) {
+          stateToUpdate.eventActions[eventIndex].moveFromCurrent = true;
+          showAlert(SINGLE_STATE_EXIT_FLAG_MESSAGE, 'info');
+        }
       } else {
         stateToUpdate.eventActions.push({
           moveFromCurrent: false,
@@ -166,6 +184,19 @@ export const StateContextProvider: React.FC<PropsWithChildren> = ({
   const updateStateImmediateActions = (stateName: string, action: Action) => {
     const stateToUpdate = getStateByStateName(stateName);
     if (stateToUpdate) {
+      // Transition actions are not allowed as immediate actions in a
+      // single-state diagram (there is no event/exit-state flag to make the
+      // transition valid).
+      if (
+        action.actType === 'atTransition'
+        && isSingleStateDiagram(stateToUpdate)
+      ) {
+        showAlert(
+          'Transition actions are not allowed in the immediate actions of a single state diagram.',
+          'warning',
+        );
+        return;
+      }
       if (stateToUpdate.immediateActions.includes(action.name)) {
         return;
       }

--- a/Emrald-UI/src/tests/official/diagrams/EmraldDiagram/EmraldDiagram.test.tsx
+++ b/Emrald-UI/src/tests/official/diagrams/EmraldDiagram/EmraldDiagram.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { App } from '@/App';
@@ -69,5 +69,40 @@ describe('EmraldDiagram', () => {
     await click((await screen.findAllByText('Save'))[0]);
 
     expect(getState('StateFromDiagram')).not.toBeUndefined();
+  });
+
+  // Regression test: a state added to an already-open diagram must render on
+  // the canvas without closing and reopening the window. Previously the
+  // diagram built its nodes from a stale snapshot of the diagram's state list.
+  test('renders a newly created state on the canvas without reopening', async () => {
+    render(<App></App>);
+    const user = userEvent.setup();
+
+    // Open a diagram
+    await click((await screen.findAllByText('Diagrams'))[0]);
+    await click((await screen.findAllByText('Component'))[0]);
+    await user.dblClick(await screen.findByText('C-CKV-A'));
+
+    // Right-click on the diagram background and click "New State"
+    await rightClick(
+      (await screen.findByTestId('rf__wrapper')).children[0]?.children[0],
+    );
+    await user.click(await screen.findByText('New State'));
+
+    await waitFor(async () => {
+      expect(await screen.findByText('Create State')).not.toBeUndefined();
+    });
+
+    // Enter a name & create the state
+    await user.type(await screen.findByLabelText('Name'), 'LiveRenderedState');
+    await click((await screen.findAllByText('Save'))[0]);
+
+    // The new state's node shows up in the canvas without reopening it.
+    const canvas = await screen.findByTestId('rf__wrapper');
+    await waitFor(async () => {
+      expect(
+        await within(canvas).findByText('LiveRenderedState'),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/Emrald-UI/src/tests/official/forms/ActionForm/SingleStateDiagram.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/ActionForm/SingleStateDiagram.test.tsx
@@ -1,0 +1,102 @@
+import type {
+  Diagram,
+  DiagramType,
+  Event,
+  State,
+} from '../../../../types/EMRALD_Model';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, test } from 'vitest';
+import { ActionForm } from '../../../../components/forms/ActionForm/ActionForm';
+import { renderActionForm, updateModel } from '../../../test-utils';
+
+/**
+ * Adds a diagram of the given type to the model so that
+ * getDiagramByDiagramName can resolve a state's owning diagram type.
+ */
+function ensureDiagram(name: string, diagramType: DiagramType) {
+  updateModel(model => {
+    if (!model.DiagramList.some(d => d.name === name)) {
+      const diagram: Diagram = {
+        objType: 'Diagram',
+        name,
+        desc: '',
+        diagramType,
+        diagramLabel: diagramType === 'dtSingle' ? 'Component' : 'Plant',
+        states: [],
+        required: false,
+      };
+      model.DiagramList.push(diagram);
+    }
+    return model;
+  });
+}
+
+function makeState(diagramName: string): State {
+  return {
+    objType: 'State',
+    name: 'Test State',
+    desc: '',
+    stateType: 'stStandard',
+    diagramName,
+    immediateActions: [],
+    events: [],
+    eventActions: [],
+  };
+}
+
+const testEvent: Event = {
+  objType: 'Event',
+  name: 'Test Event',
+  desc: '',
+  evType: 'etStateCng',
+  mainItem: true,
+};
+
+/** Opens the action Type dropdown and returns the Transition option element. */
+async function openTransitionOption() {
+  const user = userEvent.setup();
+  await user.click(await screen.findByLabelText('Type'));
+  return screen.findByRole('option', { name: 'Transition' });
+}
+
+describe('ActionForm single-state diagram transition restriction', () => {
+  test('disables the Transition type for a new immediate action in a single-state diagram', async () => {
+    ensureDiagram('Single Diagram', 'dtSingle');
+    renderActionForm(<ActionForm state={makeState('Single Diagram')} />);
+
+    // Transition is greyed out / unselectable.
+    expect(await openTransitionOption()).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+
+    // The form does not default to the disabled Transition type, so the
+    // transition-specific sub-form is not rendered.
+    expect(
+      screen.queryByText(/To add a new destination state/),
+    ).not.toBeInTheDocument();
+  });
+
+  test('allows the Transition type for a new immediate action in a multi-state diagram', async () => {
+    ensureDiagram('Multi Diagram', 'dtMulti');
+    renderActionForm(<ActionForm state={makeState('Multi Diagram')} />);
+
+    expect(await openTransitionOption()).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+
+  test('allows the Transition type for an event action even in a single-state diagram', async () => {
+    ensureDiagram('Single Diagram', 'dtSingle');
+    renderActionForm(
+      <ActionForm event={testEvent} state={makeState('Single Diagram')} />,
+    );
+
+    expect(await openTransitionOption()).not.toHaveAttribute(
+      'aria-disabled',
+      'true',
+    );
+  });
+});

--- a/Emrald-UI/src/utils/util-functions.ts
+++ b/Emrald-UI/src/utils/util-functions.ts
@@ -1,6 +1,13 @@
 import moment from 'moment';
 
 /**
+ * Message shown when a transition action is added under an event in a
+ * single-state diagram and the event's "exit state" flag is auto-set.
+ */
+export const SINGLE_STATE_EXIT_FLAG_MESSAGE
+  = 'This is a single state diagram and the event property to exit the state is being set';
+
+/**
  * Converts a string in scientific notation to a numeric value rounded to 10 decimal places.
  * If the input is not in scientific notation, or if there is an error, this function will return undefined.
  * @param value - The string to convert to a numeric value


### PR DESCRIPTION
#### Description

A single-state diagram (`dtSingle`) can only be in one state at a time, so a transition action must always exit the current state — a transition that does not exit the state is logically invalid. The UI previously let users add transition actions freely in single-state diagrams. This PR constrains that and includes a few related diagram-creation UX fixes uncovered while testing.

#### Related Issue

Fixes #563

#### Changes Made

- **Immediate actions (single-state diagrams):** block dropping or pasting a transition action into the Immediate Actions section, and disable (grey out) the **Transition** type in the Action form when creating an action there. The new action defaults off the disabled Transition type.
- **Event actions (single-state diagrams):** when a transition action is added under an event — via drag-drop, the Action form, or paste — automatically set that event's "exit state" flag (`moveFromCurrent`) if it isn't already set, and notify the user: *"This is a single state diagram and the event property to exit the state is being set"*.
- **DiagramForm – group label default:** for new diagrams, default the Diagram Group Label from the diagram type (Multi State → `Plant`, Single State → `Component`) until the user sets it manually. Switching the type updates the default; a user-entered label is preserved.
- **DiagramForm – open on create:** a newly created diagram now opens automatically (replacing the create form window).
- **Fix – stale diagram canvas:** a diagram now renders states added/removed after it was opened without needing to close and reopen the window. The canvas previously built its nodes from a one-time snapshot of the diagram's state list.
- Added the per-option `disabled` capability to the shared `MainDetailsForm` type dropdown (backward compatible).

#### Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Additional Notes

- New tests:
  - `ActionForm/SingleStateDiagram.test.tsx` — Transition type is disabled for a new immediate action in a single-state diagram, and remains enabled for multi-state diagrams and for event actions.
  - `EmraldDiagram.test.tsx` — a newly created state renders on the canvas without reopening the window (verified to fail without the fix).
- Lint: changed files are clean. There are 8 pre-existing ESLint errors on `v3_Devel` in `maap-inp-parser.ts` and `ItemWithContextMenu.tsx` (untouched by this PR). The full Vitest suite has 20 pre-existing failures on `v3_Devel` unrelated to these changes; this PR adds only passing tests and introduces no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)