### PR TITLE
Fix EMRALD_Sim crash on command-line/JSON runs (window handle not created)

### DIFF
--- a/EMRALD_Sim/FormMain.cs
+++ b/EMRALD_Sim/FormMain.cs
@@ -45,6 +45,7 @@ namespace EMRALD_Sim
     private List<string> _recentFiles = new List<string>();
     private bool _skipApplyOptionsOnce = false;
     private bool _isCommandLineRun = false;
+    private bool _pendingAutoRun = false; // command-line run is deferred to FormMain_Load so the window handle exists before the sim marshals UI updates
     private Options_cur _curSimOptions = new Options_cur();
     private ContextMenuStrip _monitorVarsContextMenu = null;
 
@@ -128,10 +129,11 @@ namespace EMRALD_Sim
 
       ApplyOptionsToUI();
 
-      if (execute && _validSim)
-      {
-        btnStartSims_Click(this, null);
-      }
+      // Defer the auto-run to FormMain_Load. Starting the sim here (before Application.Run
+      // shows the form) means the window handle isn't created yet, so the background sim
+      // thread's UI marshaling (InvokeUIUpdate) throws "Invoke or BeginInvoke cannot be
+      // called on a control until the window handle has been created."
+      _pendingAutoRun = execute && _validSim;
     }
 
     // Create right-click menu for monitor vars to select/unselect all.
@@ -485,7 +487,10 @@ namespace EMRALD_Sim
     // Ensure delegate executes on UI thread.
     private void InvokeUIUpdate(MethodInvoker methodInvokerDelegate)
     {
-      if (this.InvokeRequired)
+      // Only marshal when the window handle exists; otherwise Invoke throws "Invoke or BeginInvoke
+      // cannot be called on a control until the window handle has been created." Running inline is
+      // safe before the handle exists because there's no UI thread message pump to marshal onto yet.
+      if (this.IsHandleCreated && this.InvokeRequired)
       {
         this.Invoke(methodInvokerDelegate);
       }
@@ -614,6 +619,13 @@ namespace EMRALD_Sim
         cbMsgType.Items.Add(actT.ToString().Substring(2));
       }
       cbMsgType.SelectedIndex = 0;
+
+      // Run the command-line/JSON sim now that the form is loaded and its window handle exists.
+      if (_pendingAutoRun)
+      {
+        _pendingAutoRun = false;
+        btnStartSims_Click(this, null);
+      }
     }
 
     private void cbMsgType_SelectedIndexChanged(object sender, EventArgs e)


### PR DESCRIPTION
#### Description

`EMRALD_Sim` could crash on startup when running a model headless from a JSON options file with:

```
An error occured in Main: Invoke or BeginInvoke cannot be called on a control until the window handle has been created.
```

`EMRALD_Sim` is a WinForms app even in command-line mode. `FormMain`'s constructor started a command-line/JSON run by calling `btnStartSims_Click(...)` directly — **before** `Application.Run(mainForm)` shows the form and creates its window handle. That handler spawns a background `Task.Run` that marshals progress/completion updates back to the UI via `InvokeUIUpdate` → `Control.Invoke`, which throws when the handle doesn't exist yet. `InvokeUIUpdate` only checked `InvokeRequired`, with no `IsHandleCreated` guard. The race is widened under RDP / terminal-server sessions where handle creation is deferred.

#### Related Issue

Fixes #599

#### Changes Made

- Defer the command-line/JSON auto-run from the `FormMain` constructor to `FormMain_Load` (fires after the window handle exists) via a new `_pendingAutoRun` field. Auto-run behavior is unchanged — still triggered by passing the JSON options file; it just fires a moment later, after the handle exists.
- Guard `InvokeUIUpdate` with `IsHandleCreated` as defense-in-depth so UI marshaling can never throw this error again even if another path races handle creation.

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)

N/A — no visual changes.

#### Additional Notes

Recommended manual verification: build `EMRALD.sln` and run a model headless from a JSON options file (e.g. the `Simple_WF.emrald` workflow) to confirm it completes without the Invoke error, and confirm normal GUI launch and auto-run-from-JSON both still behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
