### PR TITLE
Fix non-mutually-exclusive transition transitioning 100% of the time

### DIFF
--- a/SimulationDAL/Actions.cs
+++ b/SimulationDAL/Actions.cs
@@ -387,7 +387,10 @@ namespace SimulationDAL
         }
       }
 
-      if (retStateIDs.Count == 0) //no probability items were selected we must use the default state
+      //Only mutually exclusive transitions require a guaranteed default path (probabilities partition 1.0).
+      //For non-mutually-exclusive transitions an empty result is valid - it means no new state was selected
+      //(e.g. a single 0.5 target should transition only ~50% of the time, not fall through to a default).
+      if (mutExcl && retStateIDs.Count == 0) //no probability items were selected we must use the default state
         retStateIDs.Add(new IdxAndStr(_newStateIDs[_toStateProb.Count - 1].id, _failDesc[_toStateProb.Count - 1]));
 
       return retStateIDs;


### PR DESCRIPTION
#### Description

A non-mutually-exclusive transition action (`"mutExcl": false`) with a single "to state" at `"prob": 0.5` was transitioning to that state on **100% of runs** instead of ~50%.

The root cause is in `TransitionAct.GetToStates()` in `SimulationDAL/Actions.cs`. After the per-state probability rolls, a "default state" fallback re-added the last "to state" whenever no state had been selected. That fallback is only correct for **mutually exclusive** transitions (where probabilities partition 1.0 and the last entry is the default path), but it ran unconditionally. For a non-mutExcl single 0.5 target, the ~50% of runs where the roll failed fell through to the fallback and added the state anyway → 100% transition rate.

The fix guards the fallback with `mutExcl` so that an empty result remains a valid outcome for non-mutually-exclusive transitions (no new state selected → parent is exited with no onward transition).

#### Related Issue

Fixes #601

#### Changes Made

- Guarded the default-state fallback in `TransitionAct.GetToStates()` (`SimulationDAL/Actions.cs`) with `mutExcl`, so it only applies to mutually exclusive transitions.
- Added an explanatory comment documenting why an empty result is valid for non-mutually-exclusive transitions.

#### Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation (N/A — engine-only change, no UI impact)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (see Additional Notes)
- [x] New and existing unit tests pass locally with my changes

#### Additional Notes

This is an engine-only change in `SimulationDAL`; no UI changes.

Note on behavior: mutually-exclusive transitions are unaffected. Non-mutually-exclusive transitions whose probabilities summed to <1.0 will now sometimes select **no** state (the correct behavior), rather than always falling back to the last "to state". Models that unintentionally relied on the old fallback may see changed results.

No new automated test was added in this PR; existing unit tests pass locally. A regression test covering a single non-mutExcl 0.5 target (asserting ~50% transition over many runs) would be a good follow-up.
