### PR TITLE
Fix logic tree gate expand/collapse

### DIFF
--- a/Emrald-UI/src/components/diagrams/LogicTreeDiagram/useExpandCollapse.tsx
+++ b/Emrald-UI/src/components/diagrams/LogicTreeDiagram/useExpandCollapse.tsx
@@ -13,7 +13,10 @@ function filterCollapsedChildren(
   dagre: Dagre.graphlib.Graph<LNode>,
   node: LNode,
 ) {
-  const children = dagre.successors(node.id);
+  // NOTE: `@dagrejs/dagre`'s typings claim `successors` returns node objects,
+  // but at runtime graphlib returns an array of node id strings. We cast to
+  // reflect the real runtime type so the ids below are used directly.
+  const children = dagre.successors(node.id) as unknown as string[] | undefined;
 
   // Update this node's props so it knows if it has children and can be expanded
   // or not.
@@ -25,8 +28,11 @@ function filterCollapsedChildren(
     while (children?.length) {
       const child = children.pop();
       if (child) {
-        children.push(...(dagre.successors(child.id) ?? []));
-        dagre.removeNode(child.id);
+        const grandChildren = dagre.successors(child) as unknown as
+          | string[]
+          | undefined;
+        children.push(...(grandChildren ?? []));
+        dagre.removeNode(child);
       }
     }
   }


### PR DESCRIPTION
#### Description

Fixes the logic tree viewer's gate expand/collapse buttons, which did nothing except re-fit the diagram to the window. Collapsing a gate now hides its descendant branches and expanding restores them.

#### Related Issue

Fixes #603

#### Changes Made

- In `useExpandCollapse.tsx`, use the node id strings returned by `dagre.successors()` directly instead of reading the nonexistent `child.id` property.
- Added a comment documenting that `@dagrejs/dagre`'s typings misrepresent the runtime return type of `successors()` (it returns id strings, not node objects).

#### Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Additional Notes

Verified manually in the running UI — collapsing a gate hides its descendant branches and expanding restores them. Passes `eslint --max-warnings=0` and `tsc --noEmit`.
