### PR TITLE
[codex] Normalize non-mutExcl remainder transitions

### DIFF
--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useContextMenu.tsx
@@ -37,8 +37,8 @@ export function useContextMenu(
   const { updateState, deleteState, getStateByStateId } = useStateContext();
   const { updateDiagram, getDiagramByDiagramName } = useDiagramContext();
   const { deleteEvent } = useEventContext();
-  const { updateAction, deleteAction, getActionByActionId }
-    = useActionContext();
+  const { updateAction, deleteAction, getActionByActionId } =
+    useActionContext();
   const { showAlert } = useAlertContext();
 
   // A single-state diagram (dtSingle) can only be in one state at a time, so a
@@ -127,11 +127,7 @@ export function useContextMenu(
   };
 
   // * Context menu for edge
-  const onEdgeContextMenu = (
-    event: MouseEvent,
-    edge: Edge,
-    edges: Edge[],
-  ) => {
+  const onEdgeContextMenu = (event: MouseEvent, edge: Edge, edges: Edge[]) => {
     event.preventDefault(); // Prevent native context menu from showing
     setMenu({
       mouseX: event.clientX,
@@ -253,8 +249,8 @@ export function useContextMenu(
 
     let menuOptions = [...defaultOptions];
 
-    menuOptions
-      = type === 'event'
+    menuOptions =
+      type === 'event'
         ? menuOptions.filter(
             option =>
               option.label !== 'New Action' && option.label !== 'Paste Action',
@@ -488,8 +484,7 @@ export function useContextMenu(
 
       if (eventActions.length <= 1) {
         menuOptions = menuOptions.filter(
-          option =>
-            option.label !== 'Move Up' && option.label !== 'Move Down',
+          option => option.label !== 'Move Up' && option.label !== 'Move Down',
         );
       } else if (eventActions[0] === action.name) {
         // Remove 'Move Up' action if the item is in the first spot
@@ -759,12 +754,13 @@ export function useContextMenu(
       actionToUpdate.newStates = actionToUpdate.newStates.filter(
         state => state.toState !== targetState?.name,
       );
-      // If only one newState remains make it so it is set to -1
+      // If only one newState remains, keep a default only for mutually exclusive transitions.
       if (
         actionToUpdate.newStates.length === 1
         && actionToUpdate.newStates[0]
       ) {
-        actionToUpdate.newStates[0].prob = -1;
+        actionToUpdate.newStates[0].prob =
+          actionToUpdate.mutExcl === false ? 1.0 : -1;
       }
       updateAction(actionToUpdate);
       const newEdges = edges.filter(

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
@@ -49,6 +49,9 @@ export function useEmraldDiagram() {
   } = useStateContext();
   const { addWindow } = useWindowContext();
 
+  const defaultTransitionProbability = (action?: Action) =>
+    action?.mutExcl === false ? 1.0 : -1;
+
   // Get the edges for the state nodes
   const getEdges = (stateNodes: Node<{ state: State }>[]) => {
     setEdges([]);
@@ -183,7 +186,7 @@ export function useEmraldDiagram() {
         prob:
           currentAction?.newStates && currentAction.newStates.length > 0
             ? 0
-            : -1, // If only a single newState default to -1
+            : defaultTransitionProbability(currentAction),
         varProb: null,
         failDesc: '',
       });
@@ -233,7 +236,7 @@ export function useEmraldDiagram() {
         );
         addNewStateToAction(currentAction, {
           toState: targetState?.name ?? '',
-          prob: -1,
+          prob: defaultTransitionProbability(currentAction),
           varProb: null,
           failDesc: '',
         });

--- a/Emrald-UI/src/components/forms/ActionForm/ActionFormContext.tsx
+++ b/Emrald-UI/src/components/forms/ActionForm/ActionFormContext.tsx
@@ -36,11 +36,11 @@ export interface NewStateItem {
   probType: string;
 }
 
-export type sim3DMessageType
-  = | 'atCompModify'
-    | 'atOpenSim'
-    | 'atCancelSim'
-    | 'atPing';
+export type sim3DMessageType =
+  | 'atCompModify'
+  | 'atOpenSim'
+  | 'atCancelSim'
+  | 'atPing';
 
 export type ReturnProcessType = 'rtVar' | 'rtNone' | 'rtStateList';
 
@@ -206,19 +206,27 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
     { value: 'atRunExtApp', label: 'Run Application' },
   ];
 
+  const isRemainingProbability = (prob?: number | string | null) =>
+    Number(prob) === -1;
+
   useEffect(() => {
     setReqPropsFilled(!!name && !!actType);
   }, [name, actType]);
 
   const handleMutuallyExclusiveChange = (value: boolean) => {
     if (newStateItems) {
-      for (const newStateItem of newStateItems) {
-        checkProbability(newStateItem, newStateItems, value);
-        if (!value && newStateItem.prob === -1) {
-          newStateItem.remaining = false;
-          newStateItem.prob = 0;
-        }
+      const updatedItems = newStateItems.map(newStateItem =>
+        !value && isRemainingProbability(newStateItem.prob)
+          ? { ...newStateItem, remaining: false, prob: '1.0' }
+          : !value
+            ? { ...newStateItem, remaining: false }
+            : newStateItem,
+      );
+
+      for (const newStateItem of updatedItems) {
+        checkProbability(newStateItem, updatedItems, value);
       }
+      setNewStateItems(updatedItems);
     }
     setMutuallyExclusive(value);
   };
@@ -254,21 +262,17 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
     }
 
     if (updatedMutuallyExclusive ?? mutuallyExclusive) {
-      const totalProb
-        = updateItems?.reduce(
-          (acc, item) => (item.prob === -1 ? acc : acc + Number(item.prob)),
+      const totalProb =
+        updateItems?.reduce(
+          (acc, item) =>
+            isRemainingProbability(item.prob) ? acc : acc + Number(item.prob),
           0,
         ) ?? 0;
+      const hasRemaining =
+        updatedRemaining === true || updateItems?.some(item => item.remaining);
+      const normalizedTotal = (hasRemaining ? 1 - totalProb : 0) + totalProb;
 
-      if (
-        totalProb !== 1
-        && ((updatedRemaining !== undefined && updatedRemaining)
-          || updateItems?.some(item => item.remaining)
-          ? 1 - totalProb
-          : 0)
-        + totalProb
-        !== 1
-      ) {
+      if (totalProb !== 1 && normalizedTotal !== 1) {
         setErrorIds(
           prevErrorItemIds => new Set([...prevErrorItemIds, updatedItem.id]),
         );
@@ -306,6 +310,16 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
   };
 
   const handleSave = (event?: Event, state?: State) => {
+    const savedMutuallyExclusive = mutuallyExclusive ?? true;
+    const shouldSaveMutuallyExclusive =
+      actionData?.mutExcl !== undefined || !savedMutuallyExclusive;
+    const getSavedProbability = (newStateItem: NewStateItem) => {
+      const probability = Number(newStateItem.prob);
+      return !savedMutuallyExclusive && isRemainingProbability(probability)
+        ? 1.0
+        : probability;
+    };
+
     action.value = {
       ...action.value,
       id: actionData?.id ?? uuidv4(),
@@ -318,18 +332,18 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
               newStateItem.probType === 'fixed'
                 ? {
                     toState: newStateItem.toState,
-                    prob: Number(newStateItem.prob),
+                    prob: getSavedProbability(newStateItem),
                     failDesc: newStateItem.failDesc ?? '',
                   }
                 : {
                     toState: newStateItem.toState,
-                    prob: Number(newStateItem.prob),
+                    prob: getSavedProbability(newStateItem),
                     failDesc: newStateItem.failDesc ?? '',
                     varProb: newStateItem.varProb,
                   },
           )
         : undefined,
-      mutExcl: mutuallyExclusive,
+      mutExcl: shouldSaveMutuallyExclusive ? savedMutuallyExclusive : undefined,
       codeVariables: ['atCngVarVal', 'atRunExtApp'].includes(actType)
         ? codeVariables
         : undefined,
@@ -515,12 +529,16 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
     event: ChangeEvent<HTMLInputElement>,
     item: NewStateItem,
   ) => {
+    const checked = event.target.checked;
+    const nextRemaining = (mutuallyExclusive ?? true) && checked;
+    const nextProb = nextRemaining ? -1 : checked ? '1.0' : 0;
+
     const updatedItems = newStateItems?.map(newItem =>
       newItem === item
         ? {
             ...newItem,
-            remaining: event.target.checked,
-            prob: event.target.checked ? -1 : 0,
+            remaining: nextRemaining,
+            prob: nextProb,
           }
         : newItem,
     );
@@ -528,8 +546,8 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
     checkProbability(
       {
         ...item,
-        remaining: event.target.checked,
-        prob: event.target.checked ? -1 : 0,
+        remaining: nextRemaining,
+        prob: nextProb,
       },
       updatedItems,
     );
@@ -593,18 +611,22 @@ export const ActionFormContextProvider: React.FC<PropsWithChildren> = ({
     setDesc(actionData?.desc ?? '');
     setActType(actionData?.actType ?? 'atTransition');
     // transition items
-    setMutuallyExclusive(
-      actionData?.mutExcl === undefined ? true : actionData.mutExcl,
-    );
+    const initialMutuallyExclusive =
+      actionData?.mutExcl === undefined ? true : actionData.mutExcl;
+    setMutuallyExclusive(initialMutuallyExclusive);
     setNewStateItems(
       actionData?.newStates
         ? sortNewStates(
             actionData.newStates.map(state => ({
               ...state,
               id: uuidv4(),
-              remaining: state.prob === -1,
+              remaining:
+                initialMutuallyExclusive && isRemainingProbability(state.prob),
               probType: state.varProb ? 'variable' : 'fixed',
-              prob: toScientificIfNeeded(state.prob),
+              prob:
+                !initialMutuallyExclusive && isRemainingProbability(state.prob)
+                  ? '1.0'
+                  : toScientificIfNeeded(state.prob),
             })),
           )
         : undefined,

--- a/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.expected.json
+++ b/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.expected.json
@@ -39,7 +39,12 @@
     "mainItem": true,
     "actType": "atTransition",
     "newStates": [
-      { "toState": "Test State 1", "prob": 0, "failDesc": "", "varProb": "Test Variable" }
+      {
+        "toState": "Test State 1",
+        "prob": 0,
+        "failDesc": "",
+        "varProb": "Test Variable"
+      }
     ]
   },
   "unchecks mutually exclusive": {
@@ -50,8 +55,17 @@
     "actType": "atTransition",
     "newStates": [
       { "toState": "Test State 1", "prob": 0.4, "failDesc": "" },
-      { "toState": "Test State 2", "prob": 0, "failDesc": "" }
+      { "toState": "Test State 2", "prob": 1, "failDesc": "" }
     ],
+    "mutExcl": false
+  },
+  "normalizes non-mutually-exclusive remaining probability": {
+    "objType": "Action",
+    "name": "normalizes non-mutually-exclusive remaining probability",
+    "desc": "",
+    "mainItem": true,
+    "actType": "atTransition",
+    "newStates": [{ "toState": "Test State 1", "prob": 1, "failDesc": "" }],
     "mutExcl": false
   },
   "removes a state": {
@@ -60,8 +74,6 @@
     "desc": "",
     "mainItem": true,
     "actType": "atTransition",
-    "newStates": [
-      { "toState": "Test State 2", "prob": 0, "failDesc": "" }
-    ]
+    "newStates": [{ "toState": "Test State 2", "prob": 0, "failDesc": "" }]
   }
 }

--- a/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.test.tsx
@@ -283,6 +283,29 @@ describe('Transition Actions', () => {
     expect(getAction(name)).toEqual(expected[name]);
   });
 
+  test('normalizes non-mutually-exclusive remaining probability', async () => {
+    const name = 'normalizes non-mutually-exclusive remaining probability';
+    renderActionForm(
+      <ActionForm
+        actionData={{
+          objType: 'Action',
+          name,
+          desc: '',
+          actType: 'atTransition',
+          mainItem: true,
+          mutExcl: false,
+          newStates: [{ toState: 'Test State 1', prob: -1, failDesc: '' }],
+        }}
+      />,
+    );
+
+    expect(screen.queryByLabelText('Remaining')).not.toBeInTheDocument();
+    expect(await screen.findByLabelText('Probability')).toHaveValue('1.0');
+
+    await save();
+    expect(getAction(name)).toEqual(expected[name]);
+  });
+
   test('removes a state', async () => {
     const name = 'removes a state';
     renderActionForm(

--- a/SimulationDAL/Actions.cs
+++ b/SimulationDAL/Actions.cs
@@ -124,7 +124,15 @@ namespace SimulationDAL
     private bool hasVarProbs = false;
     public List<string> failDesc { get { return _failDesc; } set { _failDesc = value; } }
 
-    public bool mutuallyExclusive { get { return this.mutExcl; } set { this.mutExcl = value; } }
+    public bool mutuallyExclusive
+    {
+      get { return this.mutExcl; }
+      set
+      {
+        this.mutExcl = value;
+        NormalizeSingleNonMutExclRemainder();
+      }
+    }
 
     public TransitionAct()
       : base("", EnActionType.atTransition)
@@ -133,6 +141,17 @@ namespace SimulationDAL
     public TransitionAct(string name)
       : base(name, EnActionType.atTransition)
     { }
+
+    private void NormalizeSingleNonMutExclRemainder()
+    {
+      if (!mutExcl
+          && _toStateProb.Count == 1
+          && _toStateProb[0] == -1
+          && ((_toStateVarProb.Count == 0) || (_toStateVarProb[0] == null)))
+      {
+        _toStateProb[0] = 1.0;
+      }
+    }
 
     public override string GetDerivedJSON(EmraldModel lists)
     {
@@ -177,7 +196,7 @@ namespace SimulationDAL
         return false;
 
       if(dynObj.mutExcl != null)
-        mutExcl = Convert.ToBoolean(dynObj.mutExcl);
+        mutuallyExclusive = Convert.ToBoolean(dynObj.mutExcl);
 
       lists.allActions.Add(this, false);
 
@@ -227,6 +246,8 @@ namespace SimulationDAL
 
           _failDesc.Add((string)curToObj.failDesc);
         }
+
+        NormalizeSingleNonMutExclRemainder();
 
         if ((_newStateIDs.Count < 1) || (_newStateIDs.Count != _toStateProb.Count))
         {
@@ -295,6 +316,8 @@ namespace SimulationDAL
         this._failDesc.Insert(0, failDesc);
       }
 
+      NormalizeSingleNonMutExclRemainder();
+
       //RecalcBoundBoxes();
     }
 
@@ -334,6 +357,8 @@ namespace SimulationDAL
         }
 
       }
+
+      NormalizeSingleNonMutExclRemainder();
 
       List<IdxAndStr> retStateIDs = new List<IdxAndStr> { };
       double probSum = _toStateProb.Sum();

--- a/VandV_Testing/Tests_UnitAndIntegration/SimDAL_Testing.cs
+++ b/VandV_Testing/Tests_UnitAndIntegration/SimDAL_Testing.cs
@@ -400,6 +400,35 @@ namespace UnitAndIntegrationTesting
     }
 
     [Fact]
+    [Description("Non-mutually exclusive transition with one remainder state is normalized to probability 1")]
+    public void TransitionActSingleNonMutExclRemainderTest()
+    {
+      string testName = GetCurrentMethodName();
+      EmraldModel mainModel = new EmraldModel();
+      SetupTheTest(testName, mainModel);
+
+      Diagram diagram = new Diagram(EnDiagramType2.dtMulti);
+      State toState = new State("ToState", EnStateType.stStandard, diagram, -1);
+      mainModel.allStates.Add(toState, false);
+
+      TransitionAct act = new TransitionAct("NonMutExclSingleRemainder");
+      act.mutuallyExclusive = false;
+      dynamic jsonObj = JsonConvert.DeserializeObject(@"{
+        ""newStates"": [
+          { ""toState"": ""ToState"", ""prob"": -1, ""varProb"": null, ""failDesc"": """" }
+        ]
+      }");
+
+      act.LoadObjLinks(jsonObj, false, mainModel);
+
+      var selectedStates = act.WhichToState();
+      Assert.Single(selectedStates);
+      Assert.Equal(toState.id, selectedStates[0].idx);
+      Assert.Contains("\"prob\":1", act.GetDerivedJSON(mainModel));
+    }
+
+
+    [Fact]
     [Description("Test to verify that the Run exe action loads from the model correctly")]
     public void RunAppActTest()
     {


### PR DESCRIPTION
#### Description

Normalize non-mutually-exclusive transition actions that have a single target state using the `Remaining` sentinel (`prob = -1`). This prevents legacy models from reaching a transition action where `Actions.WhichToState()` returns no target state for a single non-mutually-exclusive transition.

#### Related Issue

Fixes #614

#### Changes Made

List the specific changes made in this PR:

- Normalize single-target non-mutually-exclusive transition probabilities from `-1` to `1.0` in SimulationDAL load/runtime paths.
- Update EMRALD-UI transition editing so non-mutually-exclusive actions show explicit probabilities instead of `Remaining`, converting existing `-1` values to `1.0`.
- Update diagram edge helpers so single-target non-mutually-exclusive transitions default to `1.0` instead of `-1`.
- Add SimulationDAL and ActionForm regression coverage for the legacy `mutExcl = false`, single-target `prob = -1` case.

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)

N/A

#### Additional Notes

Validation run locally:

- `dotnet test VandV_Testing\Testing.csproj --filter "FullyQualifiedName~TransitionActSingleNonMutExclRemainderTest"`
- `npm.cmd test -- --run src/tests/official/forms/ActionForm/FormFieldsByType/Transition.test.tsx -t "normalizes non-mutually-exclusive remaining probability"`
- `npm.cmd run build`

The UI build completed with the existing Vite large chunk warning.