### PR TITLE
[codex] Fix accrual variable editor state data

### DIFF
--- a/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/StateTable.tsx
+++ b/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/StateTable.tsx
@@ -29,8 +29,8 @@ import {
 import { useVariableFormContext } from '../VariableFormContext';
 
 export const StateTable: React.FC = () => {
-  const { setValue, accrualStatesData, setAccrualStatesData, sync }
-    = useVariableFormContext();
+  const { setValue, accrualStatesData, setAccrualStatesData, sync } =
+    useVariableFormContext();
   const [accrualMults, setAccrualMults] = useState<number[]>([]);
   const [multRates, setMultRates] = useState<string[]>([]);
   const [types, setTypes] = useState<string[]>([]);
@@ -117,8 +117,8 @@ export const StateTable: React.FC = () => {
       }
       setAccrualTables(newAccrualTables);
       if (accrualStatesData && accrualStatesData[index]) {
-        accrualStatesData[index].accrualTable[idx]
-          = newAccrualTables[index]?.[idx] ?? [];
+        accrualStatesData[index].accrualTable[idx] =
+          newAccrualTables[index]?.[idx] ?? [];
       }
     }
   }
@@ -172,6 +172,8 @@ export const StateTable: React.FC = () => {
             minWidth: min ? 80 : 120,
             width: min ? 'min-content' : '100%',
             my: 1,
+            '& .MuiInputLabel-root': { fontSize: '0.875rem' },
+            '& .MuiSelect-select': { fontSize: '0.875rem' },
           }}
         >
           <InputLabel id="rate-label">
@@ -186,10 +188,18 @@ export const StateTable: React.FC = () => {
             }}
             label={min ? 'Rate' : 'Multiplication Rate'}
           >
-            <MenuItem value="trSeconds">{min ? 'Sec' : 'Second'}</MenuItem>
-            <MenuItem value="trMinutes">{min ? 'Min' : 'Minute'}</MenuItem>
-            <MenuItem value="trHours">{min ? 'Hr' : 'Hour'}</MenuItem>
-            <MenuItem value="trDays">{min ? 'Day' : 'Day'}</MenuItem>
+            <MenuItem value="trSeconds" sx={{ fontSize: '0.875rem' }}>
+              {min ? 'Sec' : 'Second'}
+            </MenuItem>
+            <MenuItem value="trMinutes" sx={{ fontSize: '0.875rem' }}>
+              {min ? 'Min' : 'Minute'}
+            </MenuItem>
+            <MenuItem value="trHours" sx={{ fontSize: '0.875rem' }}>
+              {min ? 'Hr' : 'Hour'}
+            </MenuItem>
+            <MenuItem value="trDays" sx={{ fontSize: '0.875rem' }}>
+              {min ? 'Day' : 'Day'}
+            </MenuItem>
           </Select>
         </FormControl>
       )
@@ -211,12 +221,17 @@ export const StateTable: React.FC = () => {
           {accrualStatesData?.map((item, index) => (
             <StyledTableRow key={index}>
               <StyledTableCell>
-                <Typography variant="h6">{item.stateName}</Typography>
+                <Typography variant="body2" fontWeight={500}>
+                  {item.stateName}
+                </Typography>
               </StyledTableCell>
               <StyledTableCell>
                 {types[index] && (
                   <RadioGroup
-                    sx={{ margin: '8px' }}
+                    sx={{
+                      margin: '8px',
+                      '& .MuiFormControlLabel-label': { fontSize: '0.875rem' },
+                    }}
                     aria-label="status-value"
                     name="status-value"
                     value={types[index]}
@@ -228,13 +243,21 @@ export const StateTable: React.FC = () => {
                     <FormControlLabel
                       value="ctMultiplier"
                       control={
-                        <Radio checked={types[index] === 'ctMultiplier'} />
+                        <Radio
+                          size="small"
+                          checked={types[index] === 'ctMultiplier'}
+                        />
                       }
                       label="Static"
                     />
                     <FormControlLabel
                       value="ctTable"
-                      control={<Radio checked={types[index] === 'ctTable'} />}
+                      control={
+                        <Radio
+                          size="small"
+                          checked={types[index] === 'ctTable'}
+                        />
+                      }
                       label="Dynamic"
                     />
                   </RadioGroup>
@@ -254,7 +277,7 @@ export const StateTable: React.FC = () => {
                       handleStaticAccrualMultChange(event, index);
                     }}
                   />
-                  <Typography>per</Typography>
+                  <Typography variant="body2">per</Typography>
                   {getMultRateOptions(index)}
                 </StyledTableCell>
               ) : (
@@ -280,7 +303,7 @@ export const StateTable: React.FC = () => {
                         <StyledTableRow>
                           <StyledTableCell>
                             <Box display="flex" alignItems="center">
-                              <Typography sx={{ mx: 1 }}>
+                              <Typography variant="body2" sx={{ mx: 1 }}>
                                 Simulation Time
                               </Typography>
                               &nbsp;
@@ -289,7 +312,7 @@ export const StateTable: React.FC = () => {
                           </StyledTableCell>
                           <StyledTableCell>
                             <Box display="flex" alignItems="center">
-                              <Typography sx={{ mx: 1 }}>
+                              <Typography variant="body2" sx={{ mx: 1 }}>
                                 Accrual Rate
                               </Typography>
                               &nbsp;
@@ -297,7 +320,9 @@ export const StateTable: React.FC = () => {
                             </Box>
                           </StyledTableCell>
                           <StyledTableCell>
-                            <Typography sx={{ mx: 1 }}>Command</Typography>
+                            <Typography variant="body2" sx={{ mx: 1 }}>
+                              Command
+                            </Typography>
                           </StyledTableCell>
                         </StyledTableRow>
                       </TableHead>

--- a/Emrald-UI/src/components/forms/VariableForm/VariableForm.tsx
+++ b/Emrald-UI/src/components/forms/VariableForm/VariableForm.tsx
@@ -43,8 +43,10 @@ export const VariableForm: React.FC<VariableFormProps> = ({ variableData }) => {
     value,
     typeProperties,
     setValue,
+    setAccrualStatesData,
     setHasError,
     setType,
+    sync,
   } = useVariableFormContext();
   const { updateVariable, createVariable } = useVariableContext();
   const { handleClose } = useWindowContext();
@@ -57,12 +59,20 @@ export const VariableForm: React.FC<VariableFormProps> = ({ variableData }) => {
   useEffect(() => {
     setName(variableData?.name ?? '');
     setType(variableData?.type ?? 'int');
-    setValue(variableData?.value === undefined ? '' : String(variableData.value));
+    setValue(
+      variableData?.value === undefined ? '' : String(variableData.value),
+    );
     if (variableData?.name) {
       setOriginalName(variableData.name);
     }
     setDesc(variableData?.desc ?? '');
     setVarScope(variableData?.varScope ?? 'gtGlobal');
+    const accrualStatesData =
+      variableData?.varScope === 'gtAccrual'
+        ? variableData.accrualStatesData
+        : undefined;
+    setAccrualStatesData(accrualStatesData);
+    sync({ accrualStatesData });
   }, []);
 
   const handleSave = (variableData?: Variable) => {
@@ -121,7 +131,7 @@ export const VariableForm: React.FC<VariableFormProps> = ({ variableData }) => {
       appData.value.VariableList.filter(
         variable => variable.name !== originalName,
       ).some(variable => variable.name === trimmedName)
-      || /[^a-zA-Z0-9-_]/.test(trimmedName),
+        || /[^a-zA-Z0-9-_]/.test(trimmedName),
     );
     setName(updatedName);
   };

--- a/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
@@ -24,7 +24,9 @@ describe('Variable Form', () => {
     await user.type(await screen.findByLabelText('Description'), 'Desc');
     await user.type(await screen.findByLabelText('Value'), '1');
     await user.click(
-      await screen.findByLabelText('Reset to initial value for every simulation run'),
+      await screen.findByLabelText(
+        'Reset to initial value for every simulation run',
+      ),
     );
 
     await save();
@@ -35,7 +37,10 @@ describe('Variable Form', () => {
     renderVariableForm(<VariableForm />);
     const user = userEvent.setup();
 
-    await user.type(await screen.findByLabelText('Name'), 'requires_initial_value');
+    await user.type(
+      await screen.findByLabelText('Name'),
+      'requires_initial_value',
+    );
 
     expect(await screen.findByRole('button', { name: 'Save' })).toBeDisabled();
   });
@@ -94,31 +99,111 @@ describe('Variable Form', () => {
 
     // Drag the states to the form
     await user.click(await screen.findByText('States'));
-    drag(await screen.findByText('Test State'), await screen.findByText('Drop State Items Here'));
-    drag(await screen.findByText('Test State 2'), await screen.findByText('Accrual Rate'));
+    drag(
+      await screen.findByText('Test State'),
+      await screen.findByText('Drop State Items Here'),
+    );
+    drag(
+      await screen.findByText('Test State 2'),
+      await screen.findByText('Accrual Rate'),
+    );
 
     // Change second state to dynamic
     await user.click((await screen.findAllByLabelText('Dynamic'))[1]);
 
     // Set multiplication factor and rate for the first state
-    await user.type(await screen.findByLabelText('Accrual Multiplication Factor'), '2'); // This actually enters a value of 12 because the 1 is in the text field by default
+    await user.type(
+      await screen.findByLabelText('Accrual Multiplication Factor'),
+      '2',
+    ); // This actually enters a value of 12 because the 1 is in the text field by default
     await user.click(
-      await findByRole((await screen.findAllByLabelText('Multiplication Rate'))[0], 'combobox'),
+      await findByRole(
+        (await screen.findAllByLabelText('Multiplication Rate'))[0],
+        'combobox',
+      ),
     );
     await user.click(await screen.findByRole('option', { name: 'Day' }));
 
     // Add rows to the second state
     await user.click(await screen.findByText('Add Row'));
     await user.click(await screen.findByText('Add Row'));
-    await user.type((await screen.findAllByLabelText('Simulation Time'))[0], '1');
+    await user.type(
+      (await screen.findAllByLabelText('Simulation Time'))[0],
+      '1',
+    );
     await user.type((await screen.findAllByLabelText('Accrual Rate'))[0], '2');
-    await user.type((await screen.findAllByLabelText('Simulation Time'))[1], '3');
+    await user.type(
+      (await screen.findAllByLabelText('Simulation Time'))[1],
+      '3',
+    );
     await user.type((await screen.findAllByLabelText('Accrual Rate'))[1], '4');
 
     await save();
     expect(getVariable(name)).toEqual(expected[name]);
   });
 
+  test('existing accrual variable displays and saves accrual states data', async () => {
+    const name = 'existing_accrual_variable';
+    renderVariableForm(
+      <VariableForm
+        variableData={{
+          objType: 'Variable',
+          name,
+          desc: '',
+          varScope: 'gtAccrual',
+          value: 0,
+          type: 'double',
+          accrualStatesData: [
+            {
+              stateName: 'Existing Static State',
+              type: 'ctMultiplier',
+              accrualMult: 3,
+              multRate: 'trMinutes',
+              accrualTable: [],
+            },
+            {
+              stateName: 'Existing Dynamic State',
+              type: 'ctTable',
+              accrualMult: 1,
+              multRate: 'trHours',
+              accrualTable: [
+                [0, 2],
+                [4, 5],
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(
+      await screen.findByText('Existing Static State'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('Existing Dynamic State'),
+    ).toBeInTheDocument();
+
+    await save();
+    expect(getVariable(name)?.accrualStatesData).toEqual([
+      {
+        stateName: 'Existing Static State',
+        type: 'ctMultiplier',
+        accrualMult: 3,
+        multRate: 'trMinutes',
+        accrualTable: [],
+      },
+      {
+        stateName: 'Existing Dynamic State',
+        type: 'ctTable',
+        accrualMult: 1,
+        multRate: 'trHours',
+        accrualTable: [
+          [0, 2],
+          [4, 5],
+        ],
+      },
+    ]);
+  });
   test('ext sim variable', async () => {
     const name = 'ext_sim_variable';
     renderVariableForm(
@@ -166,7 +251,12 @@ describe('Variable Form', () => {
     await user.type(await screen.findByLabelText('3DSimID'), '1234');
 
     // Select the external sim from the dropdown
-    await user.click(await findByRole(await screen.findByLabelText('External Sim'), 'combobox'));
+    await user.click(
+      await findByRole(
+        await screen.findByLabelText('External Sim'),
+        'combobox',
+      ),
+    );
     await user.click(await screen.findByRole('option', { name: 'MooseSim' }));
 
     await save();
@@ -195,7 +285,10 @@ describe('Variable Form', () => {
     );
 
     // The External Sim field should show the linked sim's name.
-    const combobox = await findByRole(await screen.findByLabelText('External Sim'), 'combobox');
+    const combobox = await findByRole(
+      await screen.findByLabelText('External Sim'),
+      'combobox',
+    );
     expect(combobox).toHaveTextContent('MooseSim');
   });
 
@@ -216,11 +309,17 @@ describe('Variable Form', () => {
     const user = userEvent.setup();
 
     // Enter values
-    await user.click(await findByRole(await screen.findByLabelText('Doc Type'), 'combobox'));
+    await user.click(
+      await findByRole(await screen.findByLabelText('Doc Type'), 'combobox'),
+    );
     await user.click(await screen.findByRole('option', { name: 'JSON' }));
     await user.type(await screen.findByLabelText('Doc Path'), 'C:/');
     await user.type(await screen.findByLabelText('Var Link'), 'Test');
-    await user.click(await screen.findByLabelText('Doc Path and Var Link must exist on startup'));
+    await user.click(
+      await screen.findByLabelText(
+        'Doc Path and Var Link must exist on startup',
+      ),
+    );
     await user.type(await screen.findByLabelText('Default'), 'Default');
 
     await save();


### PR DESCRIPTION
## Summary

Fixes the EMRALD-UI accrual variable editor so existing `accrualStatesData` is loaded into the State Accrual Variables table when editing an accrual variable and is preserved on save.

Also normalizes the State Accrual Variables table typography so state names, radio labels, and accrual rate combo-box text match the surrounding form scale.

## Root Cause

The accrual variable form path did not initialize the variable form context with `variableData.accrualStatesData`; that initialization only happened in another field path. The table also used larger/default typography for some row controls.

## Validation

- `npm.cmd test -- --run src/tests/official/forms/VariableForm/VariableForm.test.tsx`

Closes #620