### PR TITLE
Fix Text RegEx tester link

### DIFF
--- a/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/DocLinkFields.tsx
+++ b/Emrald-UI/src/components/forms/VariableForm/FormFieldsByType/DocLinkFields.tsx
@@ -140,9 +140,11 @@ export const DocLinkFields: React.FC<VariableFormProps> = ({
         <Link
           target="_blank"
           href={
-            docType === 'dtXML' || docType === 'dtTextRegEx'
+            docType === 'dtXML'
               ? 'https://www.site24x7.com/tools/xpath-evaluator.html'
-              : 'https://jsonpath.com/'
+              : docType === 'dtJSON'
+                ? 'https://jsonpath.com/'
+                : 'https://regex101.com/'
           }
         >
           Tester

--- a/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/VariableForm/VariableForm.test.tsx
@@ -325,4 +325,30 @@ describe('Variable Form', () => {
     await save();
     expect(getVariable(name)).toEqual(expected[name]);
   });
+
+  test('uses a regular expression tester for Text RegEx links', async () => {
+    renderVariableForm(
+      <VariableForm
+        variableData={{
+          objType: 'Variable',
+          name: 'regex_tester_link',
+          desc: '',
+          varScope: 'gtDocLink',
+          value: '',
+          type: 'string',
+        }}
+      />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(
+      await findByRole(await screen.findByLabelText('Doc Type'), 'combobox'),
+    );
+    await user.click(await screen.findByRole('option', { name: 'Text RegEx' }));
+
+    expect(await screen.findByRole('link', { name: 'Tester' })).toHaveAttribute(
+      'href',
+      'https://regex101.com/',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Text RegEx pointed to the XPath tester. Point it to regex101.

Fixes #616

## Validation

- VariableForm suite: 11 passed
- `npm.cmd run build`
- ESLint and Prettier on changed files
- Full UI suite: 118 passed, 12 failures outside this diff in Transition, Distribution, and Template form tests