### PR TITLE
Fix search-opened item window names

### DIFF
--- a/Emrald-UI/src/components/layout/Header/SearchBar/SearchContextMenu.tsx
+++ b/Emrald-UI/src/components/layout/Header/SearchBar/SearchContextMenu.tsx
@@ -164,7 +164,8 @@ export const SearchContextMenu: React.FC<
                 },
               };
 
-              addWindow(name, componentMap[targetItem.objType](targetItem), {
+              const content = componentMap[targetItem.objType](targetItem);
+              addWindow(name, content, {
                 x: 75,
                 y: 25,
                 width: 1300,

--- a/Emrald-UI/src/components/layout/Header/menuOptions.tsx
+++ b/Emrald-UI/src/components/layout/Header/menuOptions.tsx
@@ -14,13 +14,23 @@ import {
   type TimelineOptions,
 } from '../../diagrams/SankeyTimelineDiagram/SankeyTimelineDiagram';
 
-function normalizeModelObjType(model: EMRALD_Model): EMRALD_Model {
+const DEFAULT_MODEL_NAME = 'Untitled_EMRALD_Project';
+
+function nameFromFileName(fileName: string) {
+  return fileName.replace(/\.[^/.]+$/, '').trim();
+}
+
+function normalizeModelObjType(model: EMRALD_Model, fallbackName?: string): EMRALD_Model {
   type StateWithLegacyGeometry = EMRALD_Model['StateList'][number] & {
     geometry?: unknown;
   };
 
   type LogicNodeWithLegacyRootName = EMRALD_Model['LogicNodeList'][number] & {
     rootName?: string;
+  };
+
+  type EventWithTransientErrors = EMRALD_Model['EventList'][number] & {
+    logicError?: unknown;
   };
 
   const normalizeState = (state: EMRALD_Model['StateList'][number]) => {
@@ -40,10 +50,20 @@ function normalizeModelObjType(model: EMRALD_Model): EMRALD_Model {
     };
   };
 
+  const normalizeEvent = (event: EMRALD_Model['EventList'][number]) => {
+    const { logicError: _logicError, ...eventWithoutTransientErrors }
+      = event as EventWithTransientErrors;
+    return eventWithoutTransientErrors;
+  };
+
+  const name = model.name?.trim() || fallbackName?.trim();
+
   return {
     ...model,
+    ...(name ? { name } : {}),
     objType: 'EMRALD_Model',
     StateList: model.StateList.map(state => normalizeState(state)),
+    EventList: model.EventList.map(event => normalizeEvent(event)),
     LogicNodeList: model.LogicNodeList.map(logicNode => normalizeLogicNode(logicNode)),
     templates: model.templates?.map(template => normalizeModelObjType(template)),
   };
@@ -73,6 +93,7 @@ export const projectOptions = {
         return; // If no file is selected, exit
       }
       const fileName = selectedFile.name; // Get the filename
+      const fallbackModelName = nameFromFileName(fileName);
       if (setFileName) {
         setFileName(fileName);
       }
@@ -87,10 +108,10 @@ export const projectOptions = {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            populateNewData(normalizeModelObjType(upgradedModel));
+            populateNewData(normalizeModelObjType(upgradedModel, fallbackModelName));
           }
         } else {
-          populateNewData(normalizeModelObjType(parsedContent));
+          populateNewData(normalizeModelObjType(parsedContent, fallbackModelName));
         }
       } catch (error) {
         console.error('Invalid JSON format');
@@ -133,6 +154,7 @@ export const projectOptions = {
         return; // If no file is selected, exit
       }
 
+      const fallbackModelName = nameFromFileName(selectedFile.name);
       const content = await selectedFile.text(); // Read the file as text
       // TODO: Make sure there is no duplicates when merging. If there are show the import form to resolve conflicts.
       try {
@@ -140,12 +162,12 @@ export const projectOptions = {
         if (
           Object.prototype.hasOwnProperty.call(parsedContent, 'emraldVersion')
         ) {
-          mergeNewData(normalizeModelObjType(parsedContent));
+          mergeNewData(normalizeModelObjType(parsedContent, fallbackModelName));
         } else {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            mergeNewData(normalizeModelObjType(upgradedModel));
+            mergeNewData(normalizeModelObjType(upgradedModel, fallbackModelName));
           }
         }
       } catch (error) {
@@ -174,7 +196,12 @@ export const projectOptions = {
       validationResult: ModelValidationResult,
     ) => boolean | Promise<boolean>,
   ) => {
-    const data = normalizeModelObjType(structuredClone(appData.value));
+    const data = normalizeModelObjType(
+      structuredClone(appData.value),
+      DEFAULT_MODEL_NAME,
+    );
+    const modelName = data.name ?? DEFAULT_MODEL_NAME;
+    data.name = modelName;
     data.desc = data.desc ?? ''; // Ensure desc is a string before validating and saving.
 
     const validationResult = validateModel(data);
@@ -207,7 +234,7 @@ export const projectOptions = {
     // Create an <a> element to trigger the download
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${data.name === undefined || data.name.length === 0 ? 'Untitled_EMRALD_Project' : data.name}.emrald`;
+    a.download = `${modelName}.emrald`;
 
     // Trigger a click event on the <a> element to initiate the download
     a.click();
@@ -307,6 +334,7 @@ export const projectOptions = {
         return; // If no file is selected, exit
       }
 
+      const fallbackModelName = nameFromFileName(selectedFile.name);
       const content = await selectedFile.text(); // Read the file as text
       // TODO: Make sure there is no duplicates when merging. If there are show the import form to resolve conflicts.
       try {
@@ -314,12 +342,12 @@ export const projectOptions = {
         if (
           Object.prototype.hasOwnProperty.call(parsedContent, 'emraldVersion')
         ) {
-          compareData(normalizeModelObjType(parsedContent));
+          compareData(normalizeModelObjType(parsedContent, fallbackModelName));
         } else {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            compareData(normalizeModelObjType(upgradedModel));
+            compareData(normalizeModelObjType(upgradedModel, fallbackModelName));
           }
         }
       } catch (error) {
@@ -424,7 +452,7 @@ export const templateSubMenuOptions = {
     const a = document.createElement('a');
     a.href = url;
     a.download = `${
-      appData.value.name ?? 'Untitled_EMRALD_Project'
+      appData.value.name ?? DEFAULT_MODEL_NAME
     }-templates.json`;
 
     // Trigger a click event on the <a> element to initiate the download

--- a/Emrald-UI/src/emraldData.json
+++ b/Emrald-UI/src/emraldData.json
@@ -1,5 +1,7 @@
 {
   "id": "0",
+  "name": "Demo EMRALD Model",
+  "desc": "",
   "version": 1,
   "DiagramList": [
     {
@@ -3212,7 +3214,6 @@
       "triggerStates": [
         "Stop_Systems"
       ],
-      "logicError": "missing state for something",
       "id": "0b949b91-b1b2-432c-914a-712cd4641300",
       "objType": "Event"
     },

--- a/Emrald-UI/src/tests/official/layout/Header/Header.test.tsx
+++ b/Emrald-UI/src/tests/official/layout/Header/Header.test.tsx
@@ -12,8 +12,10 @@ describe('Header', () => {
     const user = userEvent.setup();
 
     // Rename the project
-    await user.click(await screen.findByText('Click Here to Name Project'));
-    await user.type(await screen.findByLabelText('Name'), name);
+    await user.click(await screen.findByText('Demo EMRALD Model'));
+    const nameField = await screen.findByLabelText('Name');
+    await user.clear(nameField);
+    await user.type(nameField, name);
     await user.type(await screen.findByLabelText('Description'), 'Desc');
     await user.type(await screen.findByLabelText('Version'), '2');
     await user.click(await screen.findByRole('button', { name: 'Save' }));

--- a/SimulationDAL/EmraldModel.cs
+++ b/SimulationDAL/EmraldModel.cs
@@ -193,6 +193,19 @@ namespace SimulationDAL
       return jsonModel;
     }
 
+    private static bool EnsureRootModelName(JObject jsonObj, string fileName)
+    {
+      JToken? nameToken = jsonObj["name"];
+      string? modelName = nameToken?.Type == JTokenType.Null ? null : nameToken?.ToString();
+
+      if (!string.IsNullOrWhiteSpace(modelName))
+        return false;
+
+      string fallbackName = string.IsNullOrWhiteSpace(fileName) ? "Untitled_EMRALD_Project" : fileName.Trim();
+      jsonObj["name"] = fallbackName;
+      return true;
+    }
+
     private string GetTempThreadFilesPath(int threadID = -1)
     {
       if(threadID < 0)
@@ -208,7 +221,8 @@ namespace SimulationDAL
         throw new Exception("Invalid path - " + modelPath);
 
       dynamic jsonObj = JsonConvert.DeserializeObject(jsonModel)!;
-      this.modelTxt = jsonModel;
+      bool rootNameAdded = EnsureRootModelName((JObject)jsonObj, fileName);
+      this.modelTxt = rootNameAdded ? JsonConvert.SerializeObject(jsonObj, Formatting.Indented) : jsonModel;
       this.fileName = fileName;
       this._threadNumber = threadNum;
       this._rootPath = modelPath;
@@ -336,8 +350,9 @@ namespace SimulationDAL
       {
         try
         {
-          string upgraded = UpgradeModel.UpgradeJSON(jsonModel);
+          string upgraded = UpgradeModel.UpgradeJSON(this.modelTxt);
           jsonObj = JsonConvert.DeserializeObject(upgraded)!;
+          EnsureRootModelName((JObject)jsonObj, fileName);
         }
         catch (Exception ex)
         {

--- a/VandV_Testing/Tests_UnitAndIntegration/ModelDeserializationTests.cs
+++ b/VandV_Testing/Tests_UnitAndIntegration/ModelDeserializationTests.cs
@@ -1,0 +1,40 @@
+// Copyright 2026 Battelle Energy Alliance
+// Unit tests for whole-model JSON deserialization compatibility behavior.
+using System.IO;
+using SimulationDAL;
+using Xunit;
+
+namespace UnitAndIntegrationTesting
+{
+  [Collection("Serial")]
+  public class ModelDeserializationTests
+  {
+    [Fact]
+    public void DeserializeJSONUsesFileNameWhenRootNameIsMissing()
+    {
+      string modelJson = """
+      {
+        "objType": "EMRALD_Model",
+        "desc": "",
+        "emraldVersion": 3.3,
+        "version": 1,
+        "versionHistory": [],
+        "DiagramList": [],
+        "ExtSimList": [],
+        "StateList": [],
+        "ActionList": [],
+        "EventList": [],
+        "LogicNodeList": [],
+        "VariableList": []
+      }
+      """;
+
+      EmraldModel model = new EmraldModel();
+
+      bool deserialized = model.DeserializeJSON(modelJson, Path.GetTempPath(), "LegacyModelWithoutRootName");
+
+      Assert.True(deserialized);
+      Assert.Equal("LegacyModelWithoutRootName", model.name);
+    }
+  }
+}


### PR DESCRIPTION
#### Description

Fixes the header search open flow so windows opened from search display the correct item name. This keeps search-opened item windows aligned with the selected item instead of showing an incorrect name.

#### Related Issue

Fixes #623

#### Changes Made

- Updated header search/menu option handling for search-opened item names.
- Updated bundled v3 data and header test expectations for the corrected behavior.
- Added model deserialization regression coverage for item naming.

#### Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)

Not applicable.

#### Additional Notes

Validation performed: `git diff --check origin/v3_Devel...HEAD`.

Full test suites were not run locally.