### PR TITLE
Default new transition target to remaining

### DIFF
--- a/EMRALD_Sim/FormMain.cs
+++ b/EMRALD_Sim/FormMain.cs
@@ -93,6 +93,7 @@ namespace EMRALD_Sim
       }
 
       bool execute = false;
+      bool startupOptionsProvided = false;
       string model = null;
 
       if (args.Length > 0)
@@ -107,9 +108,12 @@ namespace EMRALD_Sim
 
         if (isJSON)
         {
+          startupOptionsProvided = true;
           try
           {
-            _curSimOptions = JsonConvert.DeserializeObject<Options_cur>(File.ReadAllText(args[0]));
+            _curSimOptions = JsonConvert.DeserializeObject<Options_cur>(File.ReadAllText(args[0])) ?? new Options_cur();
+            _curSimOptions.initVars = _curSimOptions.initVars ?? new List<VarInitValue>();
+            _curSimOptions.variables = _curSimOptions.variables ?? new List<string>();
             model = _curSimOptions.inpfile;
             execute = true;
             _isCommandLineRun = true;
@@ -121,13 +125,15 @@ namespace EMRALD_Sim
         }
         else
         {
+          startupOptionsProvided = true;
           execute = LoadFromArgs(args, out model);
         }
       }
 
       if (model != null && OpenModel(model))
       {
-        LoadCurSimOptionsFromDisk(model);
+        if (!startupOptionsProvided)
+          LoadCurSimOptionsFromDisk(model);
         tcMain.SelectedTab = tabSimulate;
         AddRecentFile(model);
       }

--- a/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
+++ b/Emrald-UI/src/components/diagrams/EmraldDiagram/useEmraldDiagram.tsx
@@ -50,7 +50,7 @@ export function useEmraldDiagram() {
   const { addWindow } = useWindowContext();
 
   const defaultTransitionProbability = (action?: Action) =>
-    action?.mutExcl === false ? 1.0 : -1;
+    action?.mutExcl === false ? 1 : -1;
 
   // Get the edges for the state nodes
   const getEdges = (stateNodes: Node<{ state: State }>[]) => {
@@ -300,21 +300,27 @@ export function useEmraldDiagram() {
 
   // Build the state nodes
   const getStateNodes = () => {
-    const stateNodes = getCurrentDiagramStates().map(state => {
+    const stateNodes = getCurrentDiagramStates().flatMap(state => {
       const stateDetails = getStateByStateName(state);
+      if (!stateDetails) {
+        return [];
+      }
+
       const { x, y } = {
-        x: stateDetails?.geometryInfo?.x ?? 0,
-        y: stateDetails?.geometryInfo?.y ?? 0,
+        x: stateDetails.geometryInfo?.x ?? 0,
+        y: stateDetails.geometryInfo?.y ?? 0,
       };
-      return {
-        id: stateDetails?.id ?? '',
-        position: { x, y },
-        type: 'custom',
-        data: {
-          label: state,
-          state: stateDetails,
+      return [
+        {
+          id: stateDetails.id ?? '',
+          position: { x, y },
+          type: 'custom',
+          data: {
+            label: stateDetails.name,
+            state: stateDetails,
+          },
         },
-      };
+      ];
     });
     setNodes(stateNodes);
   };

--- a/Emrald-UI/src/components/drag-and-drop/ActionDroppable.tsx
+++ b/Emrald-UI/src/components/drag-and-drop/ActionDroppable.tsx
@@ -8,23 +8,32 @@ import { useActionFormContext } from '../forms/ActionForm/ActionFormContext';
 import { ActionToStateTable } from '../forms/ActionForm/ActionToStateTable';
 
 export const ActionDropTarget: React.FC = () => {
-  const { newStateItems, setNewStateItems, sortNewStates }
+  const { newStateItems, mutuallyExclusive, setNewStateItems, sortNewStates }
     = useActionFormContext();
 
   const [{ isOver }, drop] = useDrop({
     accept: 'State',
     drop: (item?: State) => {
       if (item) {
+        const shouldUseRemaining =
+          (mutuallyExclusive ?? true) && !!newStateItems?.length;
+        const existingItems = shouldUseRemaining
+          ? newStateItems?.map(newStateItem =>
+              newStateItem.remaining
+                ? { ...newStateItem, remaining: false, prob: 0 }
+                : newStateItem,
+            )
+          : newStateItems;
         const newStateItem: NewStateItem = {
           id: uuidv4(),
           toState: item.name,
-          prob: 0,
+          prob: shouldUseRemaining ? -1 : 0,
           failDesc: '',
-          remaining: false,
+          remaining: shouldUseRemaining,
           probType: 'fixed',
         };
-        if (newStateItems) {
-          setNewStateItems(sortNewStates([...newStateItems, newStateItem]));
+        if (existingItems) {
+          setNewStateItems(sortNewStates([...existingItems, newStateItem]));
         } else {
           setNewStateItems([newStateItem]);
         }

--- a/Emrald-UI/src/components/layout/Header/menuOptions.tsx
+++ b/Emrald-UI/src/components/layout/Header/menuOptions.tsx
@@ -4,6 +4,7 @@ import type { EMRALD_Model } from '../../../types/EMRALD_Model';
 import { v4 as uuidv4 } from 'uuid';
 import { appData, clearCacheData } from '../../../hooks/useAppData';
 import { EMRALD_SchemaVersion } from '../../../types/ModelUtils';
+import { repairModelReferences } from '../../../utils/ModelRepair';
 import {
   type ModelValidationResult,
   upgradeModel,
@@ -49,6 +50,56 @@ function normalizeModelObjType(model: EMRALD_Model): EMRALD_Model {
   };
 }
 
+function formatValidationSummary(validationResult: ModelValidationResult) {
+  const visibleErrors = validationResult.errors.slice(0, 5).join('\n');
+  return validationResult.truncated
+    ? `${visibleErrors}\nAdditional errors were omitted.`
+    : visibleErrors;
+}
+
+function confirmRepairInvalidModel(validationResult: ModelValidationResult) {
+  return window.confirm(
+    `This model does not match EMRALD schema ${validationResult.schemaVersion.toString()}.\n\nRepair it before continuing?\n\nRepair removes unnamed items and clears invalid references.\n\n${formatValidationSummary(validationResult)}`,
+  );
+}
+
+function reportUnrepairableModel(
+  validationResult: ModelValidationResult,
+  handleModelError?: (message: string) => void,
+) {
+  const message = `The model was repaired, but it still does not match EMRALD schema ${validationResult.schemaVersion.toString()}.\n\n${formatValidationSummary(validationResult)}`;
+  if (handleModelError) {
+    handleModelError(message);
+  } else {
+    window.alert(message);
+  }
+}
+
+function getUsableModel(
+  model: EMRALD_Model,
+  handleModelError?: (message: string) => void,
+) {
+  const normalizedModel = normalizeModelObjType(model);
+  const validationResult = validateModel(normalizedModel);
+
+  if (validationResult.valid) {
+    return normalizedModel;
+  }
+
+  if (!confirmRepairInvalidModel(validationResult)) {
+    return null;
+  }
+
+  const repairedModel = repairModelReferences(normalizedModel);
+  const repairedValidationResult = validateModel(repairedModel);
+  if (!repairedValidationResult.valid) {
+    reportUnrepairableModel(repairedValidationResult, handleModelError);
+    return null;
+  }
+
+  return repairedModel;
+}
+
 export const projectOptions = {
   New(newProject: () => void) {
     newProject();
@@ -87,10 +138,16 @@ export const projectOptions = {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            populateNewData(normalizeModelObjType(upgradedModel));
+            const usableModel = getUsableModel(upgradedModel, handleModelError);
+            if (usableModel) {
+              populateNewData(usableModel);
+            }
           }
         } else {
-          populateNewData(normalizeModelObjType(parsedContent));
+          const usableModel = getUsableModel(parsedContent, handleModelError);
+          if (usableModel) {
+            populateNewData(usableModel);
+          }
         }
       } catch (error) {
         console.error('Invalid JSON format');
@@ -140,12 +197,18 @@ export const projectOptions = {
         if (
           Object.prototype.hasOwnProperty.call(parsedContent, 'emraldVersion')
         ) {
-          mergeNewData(normalizeModelObjType(parsedContent));
+          const usableModel = getUsableModel(parsedContent, handleModelError);
+          if (usableModel) {
+            mergeNewData(usableModel);
+          }
         } else {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            mergeNewData(normalizeModelObjType(upgradedModel));
+            const usableModel = getUsableModel(upgradedModel, handleModelError);
+            if (usableModel) {
+              mergeNewData(usableModel);
+            }
           }
         }
       } catch (error) {
@@ -174,10 +237,10 @@ export const projectOptions = {
       validationResult: ModelValidationResult,
     ) => boolean | Promise<boolean>,
   ) => {
-    const data = normalizeModelObjType(structuredClone(appData.value));
+    let data = normalizeModelObjType(structuredClone(appData.value));
     data.desc = data.desc ?? ''; // Ensure desc is a string before validating and saving.
 
-    const validationResult = validateModel(data);
+    let validationResult = validateModel(data);
     if (!validationResult.valid) {
       console.error('Model validation failed:', {
         schemaVersion: validationResult.schemaVersion,
@@ -185,14 +248,21 @@ export const projectOptions = {
         truncated: validationResult.truncated,
         firstError: validationResult.errors[0],
       });
-      const shouldSave = confirmInvalidModelSave
-        ? await confirmInvalidModelSave(validationResult)
-        : window.confirm(
-            `This model does not match EMRALD schema ${validationResult.schemaVersion.toString()}. Save anyway?`,
-          );
+      if (confirmRepairInvalidModel(validationResult)) {
+        data = repairModelReferences(data);
+        validationResult = validateModel(data);
+      }
 
-      if (!shouldSave) {
-        return;
+      if (!validationResult.valid) {
+        const shouldSave = confirmInvalidModelSave
+          ? await confirmInvalidModelSave(validationResult)
+          : window.confirm(
+              `This model does not match EMRALD schema ${validationResult.schemaVersion.toString()}. Save anyway?`,
+            );
+
+        if (!shouldSave) {
+          return;
+        }
       }
     }
 
@@ -314,12 +384,18 @@ export const projectOptions = {
         if (
           Object.prototype.hasOwnProperty.call(parsedContent, 'emraldVersion')
         ) {
-          compareData(normalizeModelObjType(parsedContent));
+          const usableModel = getUsableModel(parsedContent, handleModelError);
+          if (usableModel) {
+            compareData(usableModel);
+          }
         } else {
           const upgradedModel = upgradeModel(content);
           if (upgradedModel) {
             upgradedModel.id = uuidv4();
-            compareData(normalizeModelObjType(upgradedModel));
+            const usableModel = getUsableModel(upgradedModel, handleModelError);
+            if (usableModel) {
+              compareData(usableModel);
+            }
           }
         }
       } catch (error) {
@@ -373,12 +449,18 @@ export const templateSubMenuOptions = {
         const parsedContent = JSON.parse(content) as EMRALD_Model[];
         for (const model of parsedContent) {
           if (Object.prototype.hasOwnProperty.call(model, 'emraldVersion')) {
-            mergeTemplateToList(normalizeModelObjType(model));
+            const usableModel = getUsableModel(model, handleModelError);
+            if (usableModel) {
+              mergeTemplateToList(usableModel);
+            }
           } else {
             const upgradedModel = upgradeModel(JSON.stringify(model));
             if (upgradedModel) {
               upgradedModel.id = uuidv4();
-              mergeTemplateToList(normalizeModelObjType(upgradedModel));
+              const usableModel = getUsableModel(upgradedModel, handleModelError);
+              if (usableModel) {
+                mergeTemplateToList(usableModel);
+              }
             }
           }
         }

--- a/Emrald-UI/src/hooks/useAppData.tsx
+++ b/Emrald-UI/src/hooks/useAppData.tsx
@@ -2,18 +2,42 @@ import type { EMRALD_Model } from '../types/EMRALD_Model';
 import { signal } from '@preact/signals-react';
 import emraldData from '../emraldData.json';
 import { CreateEmptyEMRALDModel } from '../types/ModelUtils';
-import { upgradeModel } from '../utils/Upgrades/upgrade';
+import { repairModelReferences } from '../utils/ModelRepair';
+import { upgradeModel, validateModel } from '../utils/Upgrades/upgrade';
 
 const storedData = sessionStorage.getItem('appData');
 
 export const appData = signal(CreateEmptyEMRALDModel());
+
+function repairInvalidStartupModel(model: EMRALD_Model, source: string) {
+  const validationResult = validateModel(model);
+  if (validationResult.valid) {
+    return model;
+  }
+
+  const shouldRepair = window.confirm(
+    `${source} does not match EMRALD schema ${validationResult.schemaVersion.toString()}. Repair it before continuing? Repair removes unnamed items and clears invalid references.`,
+  );
+  if (!shouldRepair) {
+    return null;
+  }
+
+  const repairedModel = repairModelReferences(model);
+  const repairedValidationResult = validateModel(repairedModel);
+  if (!repairedValidationResult.valid) {
+    console.error('Could not repair startup model', repairedValidationResult.errors);
+    return null;
+  }
+
+  return repairedModel;
+}
 
 // Try to parse & upgrade the stored model
 if (storedData === null) {
   // Load & upgrades the default model
   const upgraded = upgradeModel(JSON.stringify(emraldData));
   if (upgraded) {
-    appData.value = upgraded;
+    appData.value = repairModelReferences(upgraded);
   } else {
     // Something has gone really wrong and the default model failed to upgrade
     // TODO: This needs an actual notification in the UI
@@ -26,7 +50,10 @@ if (storedData === null) {
     // TODO: This needs an actual notification in the UI
     console.error('Could not upgrade local model');
   } else {
-    appData.value = upgraded;
+    const usableModel = repairInvalidStartupModel(upgraded, 'The cached model');
+    if (usableModel) {
+      appData.value = usableModel;
+    }
   }
 }
 

--- a/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.expected.json
+++ b/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.expected.json
@@ -7,7 +7,7 @@
     "actType": "atTransition",
     "newStates": [
       { "toState": "Test State 1", "prob": 0.4, "failDesc": "" },
-      { "toState": "Test State 2", "prob": 0, "failDesc": "" }
+      { "toState": "Test State 2", "prob": -1, "failDesc": "" }
     ]
   },
   "uses scientific notation": {
@@ -18,7 +18,8 @@
     "actType": "atTransition",
     "newStates": [
       { "toState": "Test State 1", "prob": 0.00002, "failDesc": "" }
-    ]
+    ],
+    "mutExcl": false
   },
   "uses remaining probability": {
     "objType": "Action",
@@ -29,8 +30,7 @@
     "newStates": [
       { "toState": "Test State 1", "prob": 0.4, "failDesc": "" },
       { "toState": "Test State 2", "prob": -1, "failDesc": "" }
-    ],
-    "mutExcl": true
+    ]
   },
   "uses variables": {
     "objType": "Action",
@@ -74,6 +74,6 @@
     "desc": "",
     "mainItem": true,
     "actType": "atTransition",
-    "newStates": [{ "toState": "Test State 2", "prob": 0, "failDesc": "" }]
+    "newStates": [{ "toState": "Test State 2", "prob": -1, "failDesc": "" }]
   }
 }

--- a/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.test.tsx
+++ b/Emrald-UI/src/tests/official/forms/ActionForm/FormFieldsByType/Transition.test.tsx
@@ -79,6 +79,13 @@ describe('Transition Actions', () => {
       await screen.findByText('Drop State Items Here'),
     );
 
+    // Allow a probability below 1 for this transition.
+    await user.click(
+      await screen.findByLabelText(
+        'Mutually Exclusive (Transitions to one and only one of the states)',
+      ),
+    );
+
     // Enter probability for state 1
     await user.type(
       (await screen.findAllByLabelText('Probability'))[0] as Element,
@@ -164,22 +171,12 @@ describe('Transition Actions', () => {
       await screen.findByText('Fixed Value or Variable'),
     );
 
-    // Check mutually exclusive
-    await user.click(
-      await screen.findByLabelText(
-        'Mutually Exclusive (Transitions to one and only one of the states)',
-      ),
-    );
+    expect(await screen.findByLabelText('Remaining')).toBeChecked();
 
     // Enter probability for state 1
     await user.type(
       (await screen.findAllByLabelText('Probability'))[0] as Element,
       '0.4',
-    );
-
-    // Check remaining for state 2
-    await user.click(
-      (await screen.findAllByLabelText('Remaining'))[1] as Element,
     );
 
     await save();
@@ -254,22 +251,12 @@ describe('Transition Actions', () => {
       await screen.findByText('Fixed Value or Variable'),
     );
 
-    // Check mutually exclusive
-    await user.click(
-      await screen.findByLabelText(
-        'Mutually Exclusive (Transitions to one and only one of the states)',
-      ),
-    );
+    expect(await screen.findByLabelText('Remaining')).toBeChecked();
 
     // Enter probability for state 1
     await user.type(
       (await screen.findAllByLabelText('Probability'))[0] as Element,
       '0.4',
-    );
-
-    // Check remaining for state 2
-    await user.click(
-      (await screen.findAllByLabelText('Remaining'))[1] as Element,
     );
 
     // Un-check mutually exclusive

--- a/Emrald-UI/src/tests/official/utils/model-repair.test.ts
+++ b/Emrald-UI/src/tests/official/utils/model-repair.test.ts
@@ -1,0 +1,145 @@
+import type { EMRALD_Model } from '@/types/EMRALD_Model';
+import { describe, expect, test } from 'vitest';
+import { EMRALD_SchemaVersion } from '@/types/ModelUtils';
+import { repairModelReferences } from '@/utils/ModelRepair';
+import { validateModel } from '@/utils/Upgrades/upgrade';
+
+function buildModel(): EMRALD_Model {
+  return {
+    objType: 'EMRALD_Model',
+    emraldVersion: EMRALD_SchemaVersion,
+    version: 1,
+    versionHistory: [],
+    DiagramList: [
+      {
+        id: 'diagram-id',
+        objType: 'Diagram',
+        name: 'Diag1',
+        desc: '',
+        diagramType: 'dtSingle',
+        diagramLabel: 'Component',
+        states: ['', '', 'OK-U1', 'MissingState', 'OK-U1'],
+      },
+    ],
+    ExtSimList: [],
+    StateList: [
+      {
+        id: 'state-id',
+        objType: 'State',
+        name: 'OK-U1',
+        desc: '',
+        stateType: 'stStandard',
+        diagramName: '',
+        immediateActions: ['', 'ActA', 'MissingAction', 'ActA'],
+        events: ['Ev1', 'MissingEvent', 'Ev2'],
+        eventActions: [
+          { actions: ['ActA', 'MissingAction'], moveFromCurrent: false },
+          { actions: ['ActA'], moveFromCurrent: true },
+        ],
+      },
+    ],
+    ActionList: [
+      {
+        id: 'action-id',
+        objType: 'Action',
+        name: 'ActA',
+        desc: '',
+        actType: 'atTransition',
+        mainItem: true,
+        newStates: [
+          { toState: 'OK-U1', prob: 1, failDesc: '', varProb: null },
+          { toState: 'MissingState', prob: 0, failDesc: '', varProb: null },
+        ],
+      },
+    ],
+    EventList: [
+      {
+        id: 'event-1-id',
+        objType: 'Event',
+        name: 'Ev1',
+        desc: '',
+        mainItem: true,
+        evType: 'etStateCng',
+        triggerStates: ['OK-U1', '', 'MissingState'],
+      },
+      {
+        id: 'event-2-id',
+        objType: 'Event',
+        name: 'Ev2',
+        desc: '',
+        mainItem: true,
+        evType: 'etTimer',
+      },
+    ],
+    LogicNodeList: [],
+    VariableList: [],
+  };
+}
+
+describe('repairModelReferences', () => {
+  test('removes unnamed items before repairing references', () => {
+    const model = buildModel();
+    model.DiagramList[0]!.name = '';
+    model.ActionList[0]!.name = '';
+
+    const repaired = repairModelReferences(model);
+    const state = repaired.StateList[0];
+
+    expect(repaired.DiagramList).toEqual([]);
+    expect(repaired.ActionList).toEqual([]);
+    expect(state?.diagramName).toBe('');
+    expect(state?.immediateActions).toEqual([]);
+    expect(state?.eventActions[0]?.actions).toEqual([]);
+  });
+
+  test('repairs stale diagram state references for named diagrams', () => {
+    const repaired = repairModelReferences(buildModel());
+    const diagram = repaired.DiagramList[0];
+    const state = repaired.StateList[0];
+
+    expect(diagram?.name).toBe('Diag1');
+    expect(diagram?.states).toEqual(['OK-U1']);
+    expect(state?.diagramName).toBe('Diag1');
+  });
+
+  test('splices invalid parallel event/eventActions entries', () => {
+    const repaired = repairModelReferences(buildModel());
+    const state = repaired.StateList[0];
+
+    expect(state?.immediateActions).toEqual(['ActA']);
+    expect(state?.events).toEqual(['Ev1', 'Ev2']);
+    expect(state?.eventActions).toEqual([
+      { actions: ['ActA'], moveFromCurrent: false },
+      { actions: [], moveFromCurrent: false },
+    ]);
+  });
+
+  test('removes invalid downstream state references', () => {
+    const repaired = repairModelReferences(buildModel());
+    const action = repaired.ActionList[0];
+    const event = repaired.EventList[0];
+
+    expect(action?.newStates).toEqual([
+      { toState: 'OK-U1', prob: 1, failDesc: '', varProb: null },
+    ]);
+    expect(event?.triggerStates).toEqual(['OK-U1']);
+  });
+});
+
+describe('validateModel semantic checks', () => {
+  test('reports empty item names that the schema permits as strings', () => {
+    const model = buildModel();
+    model.DiagramList[0]!.name = '';
+    model.StateList[0]!.name = '';
+
+    const result = validateModel(model);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      'DiagramList[0].name: Diagram name must not be empty.',
+    );
+    expect(result.errors).toContain(
+      'StateList[0].name: State name must not be empty.',
+    );
+  });
+});

--- a/Emrald-UI/src/utils/ModelRepair.ts
+++ b/Emrald-UI/src/utils/ModelRepair.ts
@@ -1,0 +1,303 @@
+import type {
+  EMRALD_Model,
+  EventActionItems,
+  MainItemType,
+} from '../types/EMRALD_Model';
+
+type NamedItem = {
+  name?: string;
+};
+
+export function hasUsableName(name: unknown): name is string {
+  return typeof name === 'string' && name.trim().length > 0;
+}
+
+function getNameSet(items: NamedItem[]) {
+  return new Set(
+    items
+      .map(item => item.name)
+      .filter((name): name is string => hasUsableName(name)),
+  );
+}
+
+function cleanReferenceList(
+  references: string[] | undefined,
+  validNames: Set<string>,
+) {
+  const cleaned: string[] = [];
+  const seen = new Set<string>();
+
+  for (const reference of references ?? []) {
+    if (
+      !hasUsableName(reference)
+      || !validNames.has(reference)
+      || seen.has(reference)
+    ) {
+      continue;
+    }
+
+    cleaned.push(reference);
+    seen.add(reference);
+  }
+
+  return cleaned;
+}
+
+function cleanScalarReference(reference: unknown, validNames: Set<string>) {
+  return hasUsableName(reference) && validNames.has(reference) ? reference : '';
+}
+
+function cleanEventAction(
+  eventAction: EventActionItems | undefined,
+  actionNames: Set<string>,
+): EventActionItems {
+  return {
+    actions: cleanReferenceList(eventAction?.actions, actionNames),
+    moveFromCurrent: eventAction?.moveFromCurrent ?? false,
+  };
+}
+
+function removeItemsWithMissingNames(model: EMRALD_Model) {
+  model.DiagramList = model.DiagramList.filter(diagram =>
+    hasUsableName(diagram.name),
+  );
+  model.StateList = model.StateList.filter(state =>
+    hasUsableName(state.name),
+  );
+  model.ActionList = model.ActionList.filter(action =>
+    hasUsableName(action.name),
+  );
+  model.EventList = model.EventList.filter(event =>
+    hasUsableName(event.name),
+  );
+  model.ExtSimList = model.ExtSimList.filter(extSim =>
+    hasUsableName(extSim.name),
+  );
+  model.LogicNodeList = model.LogicNodeList.filter(logicNode =>
+    hasUsableName(logicNode.name),
+  );
+  model.VariableList = model.VariableList.filter(variable =>
+    hasUsableName(variable.name),
+  );
+}
+
+function repairDiagramStateLists(model: EMRALD_Model) {
+  const diagramNames = getNameSet(model.DiagramList);
+  const stateByName = new Map(
+    model.StateList.map(state => [state.name, state]),
+  );
+
+  for (const diagram of model.DiagramList) {
+    const repairedStates: string[] = [];
+    const seen = new Set<string>();
+
+    for (const stateName of diagram.states) {
+      const state = stateByName.get(stateName);
+      if (!state || seen.has(stateName)) {
+        continue;
+      }
+
+      if (!hasUsableName(state.diagramName) || !diagramNames.has(state.diagramName)) {
+        state.diagramName = diagram.name;
+      }
+
+      if (state.diagramName === diagram.name) {
+        repairedStates.push(stateName);
+        seen.add(stateName);
+      }
+    }
+
+    diagram.states = repairedStates;
+  }
+}
+
+function repairStateReferences(model: EMRALD_Model) {
+  const actionNames = getNameSet(model.ActionList);
+  const diagramNames = getNameSet(model.DiagramList);
+  const eventNames = getNameSet(model.EventList);
+
+  for (const state of model.StateList) {
+    state.diagramName = cleanScalarReference(state.diagramName, diagramNames);
+    state.immediateActions = cleanReferenceList(
+      state.immediateActions,
+      actionNames,
+    );
+
+    const repairedEvents: string[] = [];
+    const repairedEventActions: EventActionItems[] = [];
+
+    for (const [index, eventName] of state.events.entries()) {
+      if (!hasUsableName(eventName) || !eventNames.has(eventName)) {
+        continue;
+      }
+
+      repairedEvents.push(eventName);
+      repairedEventActions.push(
+        cleanEventAction(state.eventActions[index], actionNames),
+      );
+    }
+
+    state.events = repairedEvents;
+    state.eventActions = repairedEventActions;
+  }
+}
+
+function repairActionReferences(model: EMRALD_Model) {
+  const extSimNames = getNameSet(model.ExtSimList);
+  const stateNames = getNameSet(model.StateList);
+  const variableNames = getNameSet(model.VariableList);
+
+  for (const action of model.ActionList) {
+    if (action.extSim != null) {
+      action.extSim = cleanScalarReference(action.extSim, extSimNames);
+    }
+    if (action.variableName != null) {
+      action.variableName = cleanScalarReference(action.variableName, variableNames);
+    }
+    if (action.codeVariables != null) {
+      action.codeVariables = cleanReferenceList(action.codeVariables, variableNames);
+    }
+    if (action.newStates != null) {
+      action.newStates = action.newStates
+        .filter(newState => stateNames.has(newState.toState))
+        .map(newState => ({
+          ...newState,
+          varProb:
+            newState.varProb != null && variableNames.has(newState.varProb)
+              ? newState.varProb
+              : null,
+        }));
+    }
+  }
+}
+
+function repairEventReferences(model: EMRALD_Model) {
+  const logicNodeNames = getNameSet(model.LogicNodeList);
+  const stateNames = getNameSet(model.StateList);
+  const variableNames = getNameSet(model.VariableList);
+
+  for (const event of model.EventList) {
+    if (event.triggerStates != null) {
+      event.triggerStates = cleanReferenceList(event.triggerStates, stateNames);
+    }
+    if (event.varNames != null) {
+      event.varNames = cleanReferenceList(event.varNames, variableNames);
+    }
+    if (event.logicTop != null) {
+      event.logicTop = cleanScalarReference(event.logicTop, logicNodeNames);
+    }
+    if (event.variable != null) {
+      event.variable = cleanScalarReference(event.variable, variableNames);
+    }
+    if (event.useVariable === true && event.time != null) {
+      event.time = cleanScalarReference(event.time, variableNames);
+    }
+    if (
+      event.useVariable === true
+      && typeof event.lambda === 'string'
+      && !variableNames.has(event.lambda)
+    ) {
+      event.lambda = '';
+    }
+    if (event.parameters != null) {
+      event.parameters = event.parameters.map(parameter => {
+        if (parameter.variable == null) {
+          return parameter;
+        }
+
+        return {
+          ...parameter,
+          variable: cleanScalarReference(parameter.variable, variableNames),
+        };
+      });
+    }
+  }
+}
+
+function repairLogicNodeReferences(model: EMRALD_Model) {
+  const diagramNames = getNameSet(model.DiagramList);
+  const logicNodeNames = getNameSet(model.LogicNodeList);
+  const stateNames = getNameSet(model.StateList);
+
+  for (const logicNode of model.LogicNodeList) {
+    logicNode.gateChildren = cleanReferenceList(
+      logicNode.gateChildren,
+      logicNodeNames,
+    );
+    logicNode.compChildren = logicNode.compChildren
+      .filter(child => diagramNames.has(child.diagramName))
+      .map(child => ({
+        ...child,
+        stateValues: child.stateValues?.filter(stateValue =>
+          stateNames.has(stateValue.stateName),
+        ),
+      }));
+  }
+}
+
+function repairVariableReferences(model: EMRALD_Model) {
+  const extSimNames = getNameSet(model.ExtSimList);
+  const stateNames = getNameSet(model.StateList);
+
+  for (const variable of model.VariableList) {
+    if (variable.extSim != null) {
+      variable.extSim = cleanScalarReference(variable.extSim, extSimNames);
+    }
+    if (variable.accrualStatesData != null) {
+      variable.accrualStatesData = variable.accrualStatesData.filter(data =>
+        stateNames.has(data.stateName),
+      );
+    }
+  }
+}
+
+export function repairModelReferences(model: EMRALD_Model): EMRALD_Model {
+  const repairedModel = structuredClone(model);
+
+  removeItemsWithMissingNames(repairedModel);
+  repairDiagramStateLists(repairedModel);
+  repairStateReferences(repairedModel);
+  repairActionReferences(repairedModel);
+  repairEventReferences(repairedModel);
+  repairLogicNodeReferences(repairedModel);
+  repairVariableReferences(repairedModel);
+
+  if (repairedModel.templates) {
+    repairedModel.templates = repairedModel.templates.map(template =>
+      repairModelReferences(template),
+    );
+  }
+
+  return repairedModel;
+}
+
+export function getItemsWithEmptyNames(model: EMRALD_Model) {
+  const emptyNameItems: {
+    itemType: MainItemType;
+    listName: string;
+    index: number;
+  }[] = [];
+  const itemLists: [MainItemType, string, NamedItem[]][] = [
+    ['Diagram', 'DiagramList', model.DiagramList],
+    ['State', 'StateList', model.StateList],
+    ['Action', 'ActionList', model.ActionList],
+    ['Event', 'EventList', model.EventList],
+    ['ExtSim', 'ExtSimList', model.ExtSimList],
+    ['LogicNode', 'LogicNodeList', model.LogicNodeList],
+    ['Variable', 'VariableList', model.VariableList],
+  ];
+
+  for (const [itemType, listName, items] of itemLists) {
+    for (const [index, item] of items.entries()) {
+      if (!hasUsableName(item.name)) {
+        emptyNameItems.push({ itemType, listName, index });
+      }
+    }
+  }
+
+  for (const template of model.templates ?? []) {
+    emptyNameItems.push(...getItemsWithEmptyNames(template));
+  }
+
+  return emptyNameItems;
+}

--- a/Emrald-UI/src/utils/Upgrades/upgrade.ts
+++ b/Emrald-UI/src/utils/Upgrades/upgrade.ts
@@ -4,6 +4,7 @@ import Ajv from 'ajv';
 import { v4 as uuidv4 } from 'uuid';
 import { EMRALD_JsonSchema } from '../../types/EMRALD_Model';
 import { EMRALD_SchemaVersion } from '../../types/ModelUtils';
+import { getItemsWithEmptyNames } from '../ModelRepair';
 import { Upgrade } from './upgradeGiveID';
 
 export interface ModelValidationResult {
@@ -38,7 +39,7 @@ function formatPath(path: string) {
   return path
     .split('/')
     .filter(Boolean)
-    .map((part) => {
+    .map(part => {
       const decoded = part.replace(/~1/g, '/').replace(/~0/g, '~');
       return /^\d+$/.test(decoded) ? `[${decoded}]` : `.${decoded}`;
     })
@@ -49,7 +50,7 @@ function formatPath(path: string) {
 function groupPath(path: string) {
   const segments = path.split('/').filter(Boolean);
   const formDataIndex = segments.indexOf('formData');
-  if (formDataIndex >= 0) {
+  if (formDataIndex !== -1) {
     return formatPath(
       `/${segments.slice(0, Math.min(formDataIndex + 3, segments.length)).join('/')}`,
     );
@@ -93,6 +94,11 @@ export function validateModel(model: EMRALD_Model): ModelValidationResult {
   if (model.emraldVersion !== EMRALD_SchemaVersion) {
     addError(
       `model.emraldVersion: Model schema version ${String(model.emraldVersion)} does not match the latest schema version ${EMRALD_SchemaVersion.toString()}.`,
+    );
+  }
+  for (const item of getItemsWithEmptyNames(model)) {
+    addError(
+      `${item.listName}[${item.index.toString()}].name: ${item.itemType} name must not be empty.`,
     );
   }
   try {


### PR DESCRIPTION
#### Description

Updates the EMRALD UI transition action editor so that when Mutually Exclusive is checked, adding a new destination state to an existing transition list makes that newly added row the remaining-probability row. This restores the expected editor behavior that the latest transition target becomes the fallback destination.

#### Related Issue

N/A

#### Changes Made

- Updated the action drop target to assign `remaining: true` and `prob: -1` to newly added destination states when Mutually Exclusive is enabled and the transition list already has entries.
- Clears any previous remaining row back to a fixed `0` probability so only one destination owns the remaining probability.
- Updated transition action form tests and expected model output for the new automatic remaining behavior.

#### Type of Change

Select the type of change your PR introduces:

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

#### Checklist

Please ensure the following are completed:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] If changes effect the user interface layouts, I have updated the user documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

#### Screenshots (if applicable)

N/A

#### Additional Notes

Validation run:

```text
npm.cmd run test -- src/tests/official/forms/ActionForm
```

Result: 7 test files passed, 35 tests passed.

The test run still emits pre-existing React/MUI warnings from unrelated ActionForm tests, but this change did not introduce failing tests.
